### PR TITLE
plugin: fix(sync): prevent the plugin from crashing 

### DIFF
--- a/plugin/addons/godot_rl_agents/sync.gd
+++ b/plugin/addons/godot_rl_agents/sync.gd
@@ -15,7 +15,7 @@ var message_center
 var should_connect = true
 var agents
 var need_to_send_obs = false
-var args = null
+var args = {}
 onready var start_time = OS.get_ticks_msec()
 var initialized = false
 var just_reset = false
@@ -117,7 +117,7 @@ func _get_args():
 
 func _get_speedup():
 	print(args)
-	return args.get("speedup", str(speed_up)).to_int()
+	return int(args.get("speedup", speed_up))
 
 func _get_port():	
 	return int(args.get("port", DEFAULT_PORT))
@@ -135,9 +135,9 @@ func disconnect_from_server():
 
 func _initialize():
 	_get_agents()
-	Engine.physics_ticks_per_second = _get_speedup() * 60 # Replace with function body.
+	Engine.iterations_per_second = _get_speedup() * 60 # Replace with function body.
 	Engine.time_scale = _get_speedup() * 1.0
-	prints("physics ticks", Engine.physics_ticks_per_second, Engine.time_scale, _get_speedup(), speed_up)
+	prints("physics ticks", Engine.iterations_per_second, Engine.time_scale, _get_speedup(), speed_up)
 	
 	args = _get_args()
 	connected = connect_to_server()


### PR DESCRIPTION
by initialize args as empty dict + use iterations_per_second instead

- _get_speedup would throw an error in the editor as args would be null
- use Engine.iterations_per_second instead of Engine.physics_ticks_per_second as physics_ticks_per_second would only work in godot 4 and throws an error in godot3.5