### PR TITLE
Fix Setup config + only convert action space when convert is set to true

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv.*/
 
 # Spyder project settings
 .spyderproject

--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -56,7 +56,7 @@ class GodotEnv:
         if platform == "linux" or platform == "linux2":
             assert (
                 pathlib.Path(filename).suffix == ".x86_64"
-            ), f"incorrect file suffix for fileman {filename} suffix {pathlib.Path(filename).suffix }"
+            ), f"incorrect file suffix for filename {filename} suffix {pathlib.Path(filename).suffix }"
         elif platform == "darwin":
             assert 0, "mac is not supported, yet"
             # OS X
@@ -64,7 +64,7 @@ class GodotEnv:
             # Windows...
             assert (
                 pathlib.Path(filename).suffix == ".exe"
-            ), f"incorrect file suffix for fileman {filename} suffix {pathlib.Path(filename).suffix }"
+            ), f"incorrect file suffix for filename {filename} suffix {pathlib.Path(filename).suffix }"
         else:
             assert 0, f"unknown filetype {pathlib.Path(filename).suffix}"
 

--- a/godot_rl/core/utils.py
+++ b/godot_rl/core/utils.py
@@ -21,26 +21,28 @@ class ActionSpaceProcessor():
         self._convert = convert
 
         space_size = 0
-        if isinstance(action_space, gym.spaces.Tuple):
-            
-            for space in action_space.spaces:
-                if isinstance(space, gym.spaces.Box):
-                    assert len(space.shape) ==1
-                    space_size += space.shape[0]
-                elif isinstance(space, gym.spaces.Discrete):
-                    if space.n > 2:
-                        # for not only binary actions are supported, need to add support for the n>2 case
-                        raise NotImplementedError
-                    space_size += 1
-                else:
-                    raise NotImplementedError
-        elif isinstance(action_space, gym.spaces.Dict):
-            raise NotImplementedError
-        else:
-            assert isinstance(space, [gym.spaces.Box, gym.spaces.Discrete])
-            return 
 
-        self.converted_action_space = gym.spaces.Box(-1,1, shape=[space_size])
+        if convert:
+            if isinstance(action_space, gym.spaces.Tuple):
+                
+                for space in action_space.spaces:
+                    if isinstance(space, gym.spaces.Box):
+                        assert len(space.shape) ==1
+                        space_size += space.shape[0]
+                    elif isinstance(space, gym.spaces.Discrete):
+                        if space.n > 2:
+                            # for now only binary actions are supported, need to add support for the n>2 case
+                            raise NotImplementedError
+                        space_size += 1
+                    else:
+                        raise NotImplementedError
+            elif isinstance(action_space, gym.spaces.Dict):
+                raise NotImplementedError
+            else:
+                assert isinstance(space, [gym.spaces.Box, gym.spaces.Discrete])
+                return 
+
+            self.converted_action_space = gym.spaces.Box(-1,1, shape=[space_size])
 
     @property
     def action_space(self):

--- a/godot_rl/main.py
+++ b/godot_rl/main.py
@@ -26,7 +26,7 @@ try:
     from godot_rl.wrappers.ray_wrapper import rllib_training
 except ImportError as e:
     def rllib_training(args, extras):
-        print("Import error when trying to use rllib, this is probably not installed try pip install ray[rllib]")
+        print("Import error when trying to use rllib, this is probably not installed try pip install godot-rl[rllib]")
 
 try:
     from godot_rl.wrappers.stable_baselines_wrapper import \
@@ -34,7 +34,7 @@ try:
 except ImportError as e:
     def stable_baselines_training(args, extras):
         print(
-            "Import error when trying to use sb3, this is probably not installed try pip install stable-baselines3"
+            "Import error when trying to use sb3, this is probably not installed try pip install godot-rl[sb3]"
         )
 try:
     from godot_rl.wrappers.sample_factory_wrapper import \
@@ -43,7 +43,7 @@ except ImportError as e:
 
     def sample_factory_training(args, extras):
         print(
-            "Import error when trying to use sample-factory, this is probably not installed try pip install sample-factory"
+            "Import error when trying to use sample-factory, this is probably not installed try pip install godot-rl[sf]"
         )
 
 

--- a/godot_rl/wrappers/ray_wrapper.py
+++ b/godot_rl/wrappers/ray_wrapper.py
@@ -45,7 +45,7 @@ class RayVectorGodotEnv(VectorEnv):
     def vector_step(
         self, actions: List[EnvActionType]
     ) -> Tuple[List[EnvObsType], List[float], List[bool], List[EnvInfoDict]]:
-        actions = np.array(actions)
+        actions = np.array(actions, dtype=object)
         self.obs, reward, term, trunc, info = self._env.step(actions, order_ij=True)
         return self.obs, reward, term, info
 

--- a/godot_rl/wrappers/stable_baselines_wrapper.py
+++ b/godot_rl/wrappers/stable_baselines_wrapper.py
@@ -9,7 +9,7 @@ from godot_rl.core.utils import lod_to_dol
 
 class StableBaselinesGodotEnv(VecEnv):
     def __init__(self, env_path=None, **kwargs):
-        self.env = GodotEnv(env_path=env_path, **kwargs)
+        self.env = GodotEnv(env_path=env_path, convert_action_space=True, **kwargs)
         self._check_valid_action_space()
 
     def _check_valid_action_space(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,10 +11,10 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    numpy
+    numpy==1.23.5
     wget
     huggingface_hub>=0.10
-
+    tensorboard
 
 python_requires = >=3.8
 zip_safe = no
@@ -43,12 +43,12 @@ sb3 =
     gym==0.21
     stable-baselines3
     huggingface_sb3
-    tensorboard
 sf =
     sample-factory
     gym==0.26.2
 rllib = 
     ray[rllib]
+    tensorflow_probability
 
 clean-rl = 
     wandb

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    numpy==1.23.5
+    numpy
     wget
     huggingface_hub>=0.10
     tensorboard
@@ -43,10 +43,14 @@ sb3 =
     gym==0.21
     stable-baselines3
     huggingface_sb3
+
 sf =
     sample-factory
     gym==0.26.2
+
 rllib = 
+    numpy==1.23.5
+    ray==2.2.0
     ray[rllib]
     tensorflow_probability
 


### PR DESCRIPTION
This should enable developer to still use discrete action spaces with a size bigger than 2.
I tested this with rllib and it seems to work but I am not sure if it will break anything else? What's your take on it?

I also fixed some issues with the initial setup.
There was a trouble with ray lib and I had to fix the numpy version.
You can read about it here: https://github.com/ray-project/ray/issues/31293#issuecomment-1379007369

Cheers