### PR TITLE
Feature: Allow Users to select version 

### DIFF
--- a/godot_rl/download_utils/download_examples.py
+++ b/godot_rl/download_utils/download_examples.py
@@ -25,13 +25,13 @@ def download_examples():
     wget.download(URL, out="")
     print()
     print(f"unzipping")
-    with ZipFile("main.zip", 'r') as zipObj:
+    with ZipFile(f"{BRANCH}.zip", 'r') as zipObj:
     # Extract all the contents of zip file in different directory
         zipObj.extractall('examples/')
     print(f"cleaning up")
-    os.remove("main.zip")
+    os.remove(f"{BRANCH}.zip")
     print(f"moving files")
-    for file in os.listdir("examples/godot_rl_agents_examples-main"):
-        shutil.move(f"examples/godot_rl_agents_examples-main/{file}", "examples")
-    os.rmdir("examples/godot_rl_agents_examples-main")
+    for file in os.listdir(f"examples/godot_rl_agents_examples-{BRANCH}"):
+        shutil.move(f"examples/godot_rl_agents_examples-{BRANCH}/{file}", "examples")
+    os.rmdir(f"examples/godot_rl_agents_examples-{BRANCH}")
     

--- a/godot_rl/download_utils/download_examples.py
+++ b/godot_rl/download_utils/download_examples.py
@@ -1,0 +1,37 @@
+# we download examples from github and we save them in the examples folder
+
+import os
+import shutil
+from sys import platform
+import wget
+from zipfile import ZipFile
+
+BANCHES = {"4" : "main",
+           "3" : "godot3.5"}
+
+BASE_URL="https://github.com/edbeeching/godot_rl_agents_examples"
+
+def download_examples():
+    #select branch
+    print("Select Godot version:")
+    for key in BANCHES.keys():
+        print(f"{key} : {BANCHES[key]}")
+    
+    branch = input("Enter your choice: ")
+    BRANCH = BANCHES[branch]  
+    os.makedirs("examples", exist_ok=True)
+    URL=f"{BASE_URL}/archive/refs/heads/{BRANCH}.zip"
+    print(f"downloading examples from {URL}")
+    wget.download(URL, out="")
+    print()
+    print(f"unzipping")
+    with ZipFile("main.zip", 'r') as zipObj:
+    # Extract all the contents of zip file in different directory
+        zipObj.extractall('examples/')
+    print(f"cleaning up")
+    os.remove("main.zip")
+    print(f"moving files")
+    for file in os.listdir("examples/godot_rl_agents_examples-main"):
+        shutil.move(f"examples/godot_rl_agents_examples-main/{file}", "examples")
+    os.rmdir("examples/godot_rl_agents_examples-main")
+    

--- a/godot_rl/download_utils/download_godot_editor.py
+++ b/godot_rl/download_utils/download_godot_editor.py
@@ -4,27 +4,48 @@ from sys import platform
 import wget
 from zipfile import ZipFile
 
-VERSION="beta4"
-BASE_URL=f"https://downloads.tuxfamily.org/godotengine/4.0/{VERSION}/"
-LINUX_FILENAME=f"Godot_v4.0-{VERSION}_linux.x86_64.zip"
-MAC_FILENAME=f"Godot_v4.0-{VERSION}_macos.universal.zip"
-WINDOWS_FILENAME=f"Godot_v4.0-{VERSION}_win64.exe.zip"
+BASE_URL="https://downloads.tuxfamily.org/godotengine/"
+VERSIONS = {
+    "3": "3.5.1",
+    "4": "4.0"
+}
 
+MOST_RECENT_VERSION = "rc5"
 
+def get_version():
+    while True:
+        version = input("Which Godot version do you want to download (3 or 4)? ")
+        if version in VERSIONS:
+            return version
+        print("Invalid version. Please enter 3 or 4.")
 
 def download_editor():
+    version = get_version()
+    VERSION = VERSIONS[version]
+    NEW_BASE_URL = f"{BASE_URL}{VERSION}/{version}/"
+    NAME = "stable"
+    if VERSION == "4.0":
+        NEW_BASE_URL = f"{BASE_URL}{VERSION}/{MOST_RECENT_VERSION}/"
+        NAME = MOST_RECENT_VERSION
+    LINUX_FILENAME=f"Godot_v{VERSION}-{NAME}_linux.x86_64.zip"
+    if VERSION == "4.0":
+        MAC_FILENAME=f"Godot_v{VERSION}-{NAME}_macos.universal.zip"
+    else:
+        MAC_FILENAME=f"Godot_v{VERSION}-{NAME}_osx.universal.64.zip"
+    WINDOWS_FILENAME=f"Godot_v{VERSION}-{NAME}_win64.exe.zip"
+
     os.makedirs("editor", exist_ok=True)
     FILENAME=""
     if platform == "linux" or platform == "linux2":
        FILENAME = LINUX_FILENAME
     elif platform == "darwin":
         FILENAME = MAC_FILENAME
-    elif platform == "win64":
+    elif platform == "win32" or platform == "win64":
         FILENAME = WINDOWS_FILENAME
     else:
         raise NotImplementedError
 
-    URL=f"{BASE_URL}{FILENAME}"
+    URL=f"{NEW_BASE_URL}{FILENAME}"
 
     print(f"downloading editor {FILENAME} for platform: {platform}")
     wget.download(URL, out="")


### PR DESCRIPTION
This relies on a currently non-existent "godot3.5" branch in the godot examples repo, so we should merge after the branch is created. Also, please review the path that the example download script uses, as it's different from the previous ones, but at the same time the structure of the project has changed so I couldn't download them at envs/examples/