### PR TITLE
MacOS M1 support for rllib

### DIFF
--- a/godot_rl/main.py
+++ b/godot_rl/main.py
@@ -93,6 +93,12 @@ def get_args():
         action="store_true",
         help="wheter to export the model"
     )
+    parser.add_argument(
+        "--num_gpus",
+        default=None,
+        type=int,
+        help="Number of GPUs to use [only for rllib]"
+    )
 
     return parser.parse_known_args()
 

--- a/godot_rl/wrappers/ray_wrapper.py
+++ b/godot_rl/wrappers/ray_wrapper.py
@@ -126,6 +126,9 @@ def rllib_training(args, extras):
         run_name = exp["algorithm"] + "/editor"
     print("run_name", run_name)
 
+    if args.num_gpus != None:
+        exp["config"]["num_gpus"] = args.num_gpus
+
     if args.env_path is None:
         print("SETTING WORKERS TO 1")
         exp["config"]["num_workers"] = 1

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,9 +48,12 @@ sb3 =
 sf =
     sample-factory
     gym==0.26.2
-    
+
 rllib = 
+    numpy==1.23.5
+    ray==2.2.0
     ray[rllib]
+    tensorflow_probability
 
 clean-rl = 
     wandb


### PR DESCRIPTION
- make rllib work on apple m1 macs at least on the CPU
- make it possible to set number of gpus for rllib via gdrl command

Example command:
`gdrl --trainer=rllib --env=gdrl --env_path=absolute/path/to/JumperHard.app --num_workers=10 --experiment=JumperHard --viz  --speedup=8 --batched_sampling=True --num_gpus=0`