### PR TITLE
Feat(rllib): added possibility to set the experiment name

### DIFF
--- a/godot_rl/main.py
+++ b/godot_rl/main.py
@@ -99,6 +99,12 @@ def get_args():
         type=int,
         help="Number of GPUs to use [only for rllib]"
     )
+    parser.add_argument(
+        "--experiment_name",
+        default=None,
+        type=str,
+        help="The name of the experiment [only for rllib]"
+    )
 
     return parser.parse_known_args()
 

--- a/godot_rl/wrappers/ray_wrapper.py
+++ b/godot_rl/wrappers/ray_wrapper.py
@@ -160,6 +160,7 @@ def rllib_training(args, extras):
         checkpoint_freq=checkpoint_freq,
         checkpoint_at_end=not args.eval,
         restore=args.restore,
+        trial_name_creator=lambda trial: f"{args.experiment_name}" if args.experiment_name else f"{trial.trainable_name}_{trial.trial_id}"
     )
     if args.export:
         rllib_export(args.restore)

--- a/godot_rl/wrappers/sample_factory_wrapper.py
+++ b/godot_rl/wrappers/sample_factory_wrapper.py
@@ -149,7 +149,7 @@ def gdrl_override_defaults(_env, parser):
 def add_gdrl_env_args(_env, p: argparse.ArgumentParser, evaluation=False):
     if evaluation:
         # apparently env.render(mode="human") is not supported anymore and we need to specify the render mode in
-        # the env ctor
+        # the env actor
         p.add_argument("--render_mode", default="human", type=str, help="")
     p.add_argument("--base_port", default=0, type=int, help="")
 


### PR DESCRIPTION
Set the experiment name with `--experiment_name=nameOfYourExperiment`

```
gdrl --trainer=rllib --env=gdrl --env_path=~/platformer.x86_64 --config_file=~/ppo_config_platformer.yaml --experiment_name=platformer00
```

I initially wanted to use just the parameter `--experiment` to make it more consistent with sf but unfortunatley experiment then won't work in samplefactory anymore. Any idea how to solve this quickly?

This is how it looks in tensorboard:
![grafik](https://user-images.githubusercontent.com/6199277/224310820-26ec3a76-5476-4a18-b67e-a35c904c612a.png)
