### PR TITLE
Fixed error in _set_platform_suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# MacOS
+.DS_Store
+
 # C extensions
 *.so
 

--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -61,7 +61,7 @@ class GodotEnv:
             "win32": ".exe",
         }
         suffix = suffixes[platform]
-        return pathlib.Path(env_path).with_suffix(suffix)
+        return str(pathlib.Path(env_path).with_suffix(suffix))
 
     def check_platform(self, filename: str):
         if platform == "linux" or platform == "linux2":


### PR DESCRIPTION
`convert_macos_path` in core/utils.py expects a string of the filepath to be passed in, but when it's called in `_launch_env` the path is a `pathlib.Path` object. This happens because the method `_set_platform_suffix` overwrites the env_path string into a `pathlib.Path` object.

I'm updating the return statement of `_set_platform_suffix` to return a string instead.