### PR TITLE
feat(sb3): also track reward in tensorboard

### DIFF
--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -3,6 +3,7 @@ import argparse
 from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
 from godot_rl.wrappers.onnx.stable_baselines_export import export_ppo_model_as_onnx
 from stable_baselines3 import PPO
+from stable_baselines3.common.vec_env.vec_monitor import VecMonitor
 
 # To download the env source and binary:
 # 1.  gdrl.env_from_hub -r edbeeching/godot_rl_BallChase
@@ -29,6 +30,7 @@ args, extras = parser.parse_known_args()
 
 
 env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=True, speedup=args.speedup)
+env = VecMonitor(env)
 
 model = PPO("MultiInputPolicy", env, ent_coef=0.0001, verbose=2, n_steps=32, tensorboard_log="logs/log")
 model.learn(1000000)

--- a/godot_rl/wrappers/stable_baselines_wrapper.py
+++ b/godot_rl/wrappers/stable_baselines_wrapper.py
@@ -11,6 +11,7 @@ class StableBaselinesGodotEnv(VecEnv):
     def __init__(self, env_path=None, **kwargs):
         self.env = GodotEnv(env_path=env_path, convert_action_space=True, **kwargs)
         self._check_valid_action_space()
+        self.results = None
 
     def _check_valid_action_space(self):
         action_space = self.env.action_space
@@ -34,7 +35,7 @@ class StableBaselinesGodotEnv(VecEnv):
     def close(self):
         self.env.close()
 
-    def env_is_wrapped(self):
+    def env_is_wrapped(self, wrapper_class, indices = None):
         return [False] * self.env.num_envs
 
     @property
@@ -62,11 +63,15 @@ class StableBaselinesGodotEnv(VecEnv):
     def set_attr(self):
         raise NotImplementedError()
 
-    def step_async(self):
-        raise NotImplementedError()
+    def step_async(self, actions: np.ndarray):
+        # raise NotImplementedError()
+        # only works for single instances
+        self.results = self.step(actions)
 
     def step_wait(self):
-        raise NotImplementedError()
+        # raise NotImplementedError()
+        # only works for single instances
+        return self.results
 
 
 def stable_baselines_training(args, extras, n_steps=200000):


### PR DESCRIPTION
Added VecMonitor to SB3 example to also track the reward in tensorboard.

Current problem: This only works for single instances and not for several multithreaded instances/envs. Check out this post how multithreading could look like: https://medium.com/analytics-vidhya/understanding-openai-baseline-source-code-and-making-it-do-self-play-part-3-23eeeb6ab817