### PR TITLE
Fixes clean_rl_example.py default env path and related CUSTOM_ENV documentation section

### DIFF
--- a/docs/CUSTOM_ENV.md
+++ b/docs/CUSTOM_ENV.md
@@ -168,14 +168,16 @@ func _on_area_3d_body_entered(body):
 
 We now need to synchronize between the game running in Godot and the neural network being trained in Python. Godot RL agents provides a node that does just that. Open the train.tscn scene, right click on the root node and click “Add child node”. Then, search for “sync” and add a Godot RL Agents Sync node. This node handles the communication between Python and Godot over TCP. 
 
-You can run training live in the the editor, but first launching the python training with:
-```
-python examples/clean_rl_example.py —env-id=debug
-```
-or simply:
+You can run training live in the the editor, by first launching the python training with:
 ```
 gdrl
 ```
+alternatively you can move to the `godot_rl_agents-main` folder in the console (you can download it from the repository), and then type:
+```
+python examples/clean_rl_example.py
+```
+
+
 
 In this simple example, a reasonable policy is learned in several minutes. You may wish to speed up training, click on the Sync node in the train scene and you will see there is a “Speed Up” property exposed in the editor:
 

--- a/examples/clean_rl_example.py
+++ b/examples/clean_rl_example.py
@@ -35,8 +35,8 @@ def parse_args():
         help="whether to capture videos of the agent performances (check out `videos` folder)")
 
     # Algorithm specific arguments
-    parser.add_argument("--env_path", type=str, default="examples/godot_rl_JumperHard/bin/JumperHard.x86_64",  #examples/godot_rl_BallChase/bin/BallChase.x86_64
-        help="the id of the environment")
+    parser.add_argument("--env_path", type=str, default=None,
+        help="the path of the environment")
     parser.add_argument("--speedup", type=int, default=8,
         help="the speedup of the godot environment")
     parser.add_argument("--total-timesteps", type=int, default=1000000,


### PR DESCRIPTION
When following the custom environment tutorial (https://github.com/edbeeching/godot_rl_agents/blob/main/docs/CUSTOM_ENV.md) and using: `python examples/clean_rl_example.py —env-id=debug` some errors are encountered:

1) `clean_rl_example.py: error: unrecognized arguments: —env-id=debug`

That error is fixed in this patch by removing the argument from the documentation. 

2) `assert os.path.exists(filename)
AssertionError`

That error is fixed by removing the default path from clean_rl_example.py.