### PR TITLE
Update setup.cfg to fix sb3 not training after installing godot-rl

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     wget
     huggingface_hub>=0.10
     gym==0.26.2
-    stable-baselines3
+    stable-baselines3==1.2.0
     huggingface_sb3
     onnx
     onnxruntime
@@ -46,7 +46,7 @@ dev =
 
 sb3 =
     gym==0.26.2
-    stable-baselines3
+    stable-baselines3==1.2.0
     huggingface_sb3
 
 sf =
@@ -65,7 +65,7 @@ clean-rl =
 all =     
     numpy==1.23.5
     gym==0.26.2
-    stable-baselines3
+    stable-baselines3==1.2.0
     huggingface_sb3
     sample-factory
     


### PR DESCRIPTION
Set sb3 to use the same version as in the last successful test: https://github.com/edbeeching/godot_rl_agents/actions/runs/5348644125/jobs/9698779703?pr=117 which is `stable-baselines3-1.2.0` 

This should fix the issue (https://github.com/edbeeching/godot_rl_agents/issues/119) temporarily until potential support for sb3 2.0 gets added in the future.

The change hasn't been tested extensively, I only tried to install it on Windows using `pip install` and ran testing using `gdrl` and `clean_rl_example.py`, both of which worked. More testing is welcome. 