### PR TITLE
Changes to enable discrete actions > 2

### DIFF
--- a/godot_rl/core/utils.py
+++ b/godot_rl/core/utils.py
@@ -10,6 +10,7 @@ def lod_to_dol(lod):
 def dol_to_lod(dol):
     return [dict(zip(dol, t)) for t in zip(*dol.values())]
 
+
 def convert_macos_path(env_path):
     """
     On MacOs the user is supposed to provide a application.app file to env_path.
@@ -22,9 +23,10 @@ def convert_macos_path(env_path):
 
     filenames = re.findall(r'[^\/]+(?=\.)', env_path)
     assert (
-        len(filenames) == 1
+            len(filenames) == 1
     ), f"An error occured while converting the env path for MacOS."
     return env_path + "/Contents/MacOS/" + filenames[0]
+
 
 class ActionSpaceProcessor:
     # can convert tuple action dists to a single continuous action distribution
@@ -55,16 +57,18 @@ class ActionSpaceProcessor:
                             space_size += space.shape[0]
                         elif isinstance(space, gym.spaces.Discrete):
                             if space.n > 2:
-                                #for now only binary actions are supported if you mix different spaces
+                                # for now only binary actions are supported if you mix different spaces
                                 # need to add support for the n>2 case
-                                raise NotImplementedError
+                                raise NotImplementedError(
+                                    "Discrete actions with size larger than 2 "
+                                    "are currently not supported if used together with continuous actions.")
                             space_size += 1
                         else:
                             raise NotImplementedError
             elif isinstance(action_space, gym.spaces.Dict):
                 raise NotImplementedError
             else:
-                assert isinstance(space, [gym.spaces.Box, gym.spaces.Discrete])
+                assert isinstance(action_space, (gym.spaces.Box, gym.spaces.Discrete))
                 return
 
             if use_multi_discrete_spaces:
@@ -86,16 +90,32 @@ class ActionSpaceProcessor:
         original_action = []
         counter = 0
 
+        # If only discrete actions are used in the environment:
+        # SB3 will send int actions containing the discrete action
+        # CleanRL will send float actions
+        # If mixed actions are used, both will send float actions
+        integer_actions: bool = action.dtype == np.int64
+
         for space in self._original_action_space.spaces:
             if isinstance(space, gym.spaces.Box):
                 assert len(space.shape) == 1
-                original_action.append(action[:, counter : counter + space.shape[0]])
+                original_action.append(action[:, counter: counter + space.shape[0]])
                 counter += space.shape[0]
 
             elif isinstance(space, gym.spaces.Discrete):
+                discrete_actions = None
 
-                discrete_actions = np.greater(action[:, counter], 0.0)
-                discrete_actions = discrete_actions.astype(np.float32)
+                if integer_actions:
+                    discrete_actions = action[:, counter]
+                else:
+                    if space.n > 2:
+                        raise NotImplementedError(
+                            "Discrete actions with size larger than "
+                            "2 are currently not implemented for this algorithm.")
+                    # If the action is not an integer, convert it to a binary discrete action
+                    discrete_actions = np.greater(action[:, counter], 0.0)
+                    discrete_actions = discrete_actions.astype(np.float32)
+
                 original_action.append(discrete_actions)
                 counter += 1
 

--- a/godot_rl/wrappers/onnx/stable_baselines_export.py
+++ b/godot_rl/wrappers/onnx/stable_baselines_export.py
@@ -1,4 +1,4 @@
-from gym import spaces
+from gymnasium import spaces
 import numpy as np
 
 import torch


### PR DESCRIPTION
This is my attempt to get discrete only actions to work properly on onnx exported models with SB3 and also discrete actions > 2 to work with SB3. As I'm not very familiar with the code, libraries used and ML/RL, I will describe the approach and changes below, however in case of merging a review is requested. I'm marking this as draft as well, so any potential changes can be made before merging. I've only tested this with Stable Baselines and CleanRL example so far. 

Update: After a quick test with rllib (using the yaml file from this repo and small file changes to make training and export work for me) with discrete actions only used in the env, the onnx model outputted floats, which wouldn't work with this update (to make it compatible with the update, the onnx model would need to output integers for discrete actions in discrete-only action environments). It's also not likely to work well with the current version as the Godot plugin does not handle logits for discrete-only action spaces (adding the conversion there instead of integrating it into the models may be a potential alternative approach).

This change is connected to the draft PR for plugin (https://github.com/edbeeching/godot_rl_agents_plugin/pull/16/files#) - changes to both repositories are necessary.

**Changes to the main repository:**

Main changes to `godot_rl/core/utils.py`:
When training using SB3 on environments with only discrete actions, currently SB3 will output integer values for an action (e.g. 0,1,2,3,4), when using CleanRL example, action values will always be continuous/float values, and when using mixed spaces with SB3 the values will be continuous/float also.

- To enable Godot to receive action values larger than 2 with only discrete actions, if a discrete action is of type `np.int64`, it will be added to actions without modification, otherwise the previous logic remains to convert the discrete action from the received float value to 1 or 0 based on value. 
- Additional check is added to show an error in case of using discrete actions with size > 2 with the CleanRL example (which outputs floats/continuous values). One possible but more complex future solution might be to have two CleanRL algorithm implementations, one for continuous and one for discrete actions, and then select the right one based on the action space. 

Main changes to `godot_rl/wrappers/onnx/stable_baselines_export.py`
Currently, when exporting models that have only discrete actions using the sb3 example, the .onnx model will produce logits for the discrete actions, while sb3 model produces integers for each discrete action. This produces an error on the `verify_onnx_export` assertion.
- In this PR, I've added a check to the `forward` method, and in case the action space is `MultiDiscrete`, it should select the best action from the distribution (deterministic actions). Otherwise (for continuous or mixed actions), the old behavior is used. I've implemented this after checking the sb3 policies file to see how discrete actions are processed, however I cannot guarantee I've implemented it correctly. In a few small test cases I've tried, this makes the `verify_onnx_export` tests pass and the model works in Godot.

With that change, if the exported model uses discrete actions only (the example from the image has 2 discrete actions), the following operations are added which should select the action with the highest probability from the logits:
![Netron_ZXj1dVNn7V](https://github.com/edbeeching/godot_rl_agents/assets/61947090/ce6086d5-071c-4674-b925-59fafab24acc)

**Changes to the plugin repository:**
[ONNXInference.cs](https://github.com/edbeeching/godot_rl_agents_plugin/pull/16/files#diff-356eb1bad009a37f849867396862385fa745e2376000b81a0153a4bb68a900f0):

Previously, the exported onnx model would output float values for actions in case of either continuous or discrete actions used. After the changes above, onnx will output discrete actions as integers if only discrete actions are used in the environment. To handle that, I've made a few changes:

- Removed the types from the dictionary that stores the result and the output1 (actions) array, since they can be either int64 (long in c#) or float. An alternative approach would be to have separate methods to get actions if discrete actions are used or continuous/mixed actions are used, which would require additional changes to the gdscript plugin files. 
- Added using statements to dispose of the `session` and `results` disposable values after use.
- Replaced the load model method using Godot file access with providing the file path to InferenceSession as it can load the model. This seems to work on my PC on Windows, but I'm not sure if it could break something in some other case.

[sync.gd](https://github.com/edbeeching/godot_rl_agents_plugin/pull/16/files#diff-f787f8c54d9f84053c0eb814c447443bcd5f657ea525b827e375ceb51db71477):
- Changed clamping (to range -1 1) from all actions received from the onnx model to only continuous actions.  
- If an action is of type integer (which means a discrete action) it is added to result as is, but if it's supposed to be a discrete action and is not integer (e.g. when mixed actions are used), then it is converted to a binary discrete action. 

Simple test of output values when only discrete actions are used with the sb3 example for training after the changes (printing the received actions directly in Godot):

![image](https://github.com/edbeeching/godot_rl_agents/assets/61947090/c15bb3a2-a503-4eb5-a75d-9093cf2bc89b)
