### PR TITLE
Adds resuming and saving model to sb3 example

### DIFF
--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -103,7 +103,6 @@ else:
     path_zip = pathlib.Path(args.resume_model_path)
     print("Loading model: " + os.path.abspath(path_zip))
     model = PPO.load(path_zip, env=env, tensorboard_log=args.experiment_dir)
-    print(model.ent_coef)
 
 if args.inference:
     obs = env.reset()

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -28,7 +28,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--experiment_name",
-    default="Experiment",
+    default="experiment",
     type=str,
     help="The name of the experiment, which will be displayed in tensorboard and "
          "for checkpoint directory and name (if enabled).",

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -24,7 +24,8 @@ parser.add_argument(
     "--experiment_dir",
     default="logs/sb3",
     type=str,
-    help="The name of the experiment directory, in which the tensorboard logs and checkpoints (if enabled) are getting stored."
+    help="The name of the experiment directory, in which the tensorboard logs and checkpoints (if enabled) are "
+         "getting stored."
 )
 parser.add_argument(
     "--experiment_name",
@@ -75,6 +76,13 @@ parser.add_argument(
     help="Instead of training, it will run inference on a loaded model for --timesteps steps. "
          "Requires --resume_model_path to be set."
 )
+parser.add_argument(
+    "--viz",
+    action="store_true",
+    help="If set, the window(s) with the Godot environment(s) will be displayed, otherwise "
+         "training will run without rendering the game. Does not apply to in-editor training.",
+    default=False
+)
 parser.add_argument("--speedup", default=1, type=int, help="Whether to speed up the physics in the env")
 parser.add_argument("--n_parallel", default=1, type=int, help="How many instances of the environment executable to "
                                                               "launch - requires --env_path to be set if > 1.")
@@ -93,7 +101,10 @@ if args.save_checkpoint_frequency is not None and os.path.isdir(path_checkpoint)
 if args.inference and args.resume_model_path is None:
     raise parser.error("Using --inference requires --resume_model_path to be set.")
 
-env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=True, n_parallel=args.n_parallel,
+if args.env_path is None and args.viz:
+    print("Info: Using --viz without --env_path set has no effect, in-editor training will always render.")
+
+env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=args.viz, n_parallel=args.n_parallel,
                               speedup=args.speedup)
 env = VecMonitor(env)
 

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -24,14 +24,14 @@ parser.add_argument(
     "--experiment_dir",
     default="logs/sb3",
     type=str,
-    help="The name of the experiment directory, in which the tensorboard logs and checkpoints are getting stored."
+    help="The name of the experiment directory, in which the tensorboard logs and checkpoints (if enabled) are getting stored."
 )
 parser.add_argument(
     "--experiment_name",
     default="Experiment",
     type=str,
     help="The name of the experiment, which will be displayed in tensorboard and "
-         "for checkpoint directory and name.",
+         "for checkpoint directory and name (if enabled).",
 )
 parser.add_argument(
     "--resume_model_path",

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -38,7 +38,7 @@ parser.add_argument(
     default=None,
     type=str,
     help="The path to a model file previously saved using --save_model_path or a checkpoint saved using "
-         "--save_checkpoints_frequency. Use this to resume training from a saved model.",
+         "--save_checkpoints_frequency. Use this to resume training or infer from a saved model.",
 )
 parser.add_argument(
     "--save_model_path",

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import pathlib
 
+from stable_baselines3.common.callbacks import CheckpointCallback
 from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
 from godot_rl.wrappers.onnx.stable_baselines_export import export_ppo_model_as_onnx
 from stable_baselines3 import PPO
@@ -23,13 +24,14 @@ parser.add_argument(
     "--experiment_dir",
     default="logs/sb3",
     type=str,
-    help="The name of the experiment directory, in which the tensorboard logs are getting stored",
+    help="The name of the experiment directory, in which the tensorboard logs and checkpoints are getting stored."
 )
 parser.add_argument(
     "--experiment_name",
     default="Experiment",
     type=str,
-    help="The name of the experiment, which will be displayed in tensorboard",
+    help="The name of the experiment, which will be displayed in tensorboard and "
+         "for checkpoint directory and name.",
 )
 parser.add_argument(
     "--resume_model_path",
@@ -46,6 +48,14 @@ parser.add_argument(
          "to resume training. Extension will be set to .zip",
 )
 parser.add_argument(
+    "--save_checkpoint_frequency",
+    default=None,
+    type=int,
+    help=("If set, will save checkpoints every 'frequency' environment steps. "
+          "Requires a unique --experiment_name or --experiment_dir for each run. "
+          "Does not need --save_model_path to be set. "),
+)
+parser.add_argument(
     "--onnx_export_path",
     default=None,
     type=str,
@@ -59,10 +69,26 @@ parser.add_argument(
          "it will continue training for this amount of steps from the saved state without counting previously trained "
          "steps",
 )
+parser.add_argument(
+    "--inference",
+    action="store_true",
+    help="Instead of training, it will run inference on a loaded model for --timesteps steps. "
+         "Requires --resume_model_path to be set."
+)
 parser.add_argument("--speedup", default=1, type=int, help="Whether to speed up the physics in the env")
 parser.add_argument("--n_parallel", default=1, type=int, help="How many instances of the environment executable to "
                                                               "launch - requires --env_path to be set if > 1.")
 args, extras = parser.parse_known_args()
+
+path_checkpoint = os.path.join(args.experiment_dir, args.experiment_name + "_checkpoints")
+abs_path_checkpoint = os.path.abspath(path_checkpoint)
+
+# Prevent overwriting existing checkpoints when starting a new experiment if checkpoint saving is enabled
+if args.save_checkpoint_frequency is not None and os.path.isdir(path_checkpoint):
+    raise RuntimeError(abs_path_checkpoint + " folder already exists. "
+                                             "Use a different --experiment_dir, or --experiment_name,"
+                                             "or if previous checkpoints are not needed anymore, "
+                                             "remove the folder containing the checkpoints. ")
 
 env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=True, n_parallel=args.n_parallel, speedup=args.speedup)
 env = VecMonitor(env)
@@ -72,9 +98,25 @@ if args.resume_model_path is None:
 else:
     path_zip = pathlib.Path(args.resume_model_path)
     print("Loading model: " + os.path.abspath(path_zip))
-    model = PPO.load(path_zip, env=env)
+    model = PPO.load(path_zip, env=env, tensorboard_log=args.experiment_dir)
+    print(model.ent_coef)
 
-model.learn(args.timesteps, tb_log_name=args.experiment_name)
+if args.inference:
+    obs = env.reset()
+    for i in range(args.timesteps):
+        action, _state = model.predict(obs, deterministic=True)
+        obs, reward, done, info = env.step(action)
+else:
+    if args.save_checkpoint_frequency is None:
+        model.learn(args.timesteps, tb_log_name=args.experiment_name)
+    else:
+        print("Checkpoint saving enabled. Checkpoints will be saved to: " + abs_path_checkpoint)
+        checkpoint_callback = CheckpointCallback(
+            save_freq=(args.save_checkpoint_frequency // env.num_envs),
+            save_path=path_checkpoint,
+            name_prefix=args.experiment_name
+        )
+        model.learn(args.timesteps, callback=checkpoint_callback, tb_log_name=args.experiment_name)
 
 print("closing env")
 env.close()

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -90,7 +90,11 @@ if args.save_checkpoint_frequency is not None and os.path.isdir(path_checkpoint)
                                              "or if previous checkpoints are not needed anymore, "
                                              "remove the folder containing the checkpoints. ")
 
-env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=True, n_parallel=args.n_parallel, speedup=args.speedup)
+if args.inference and args.resume_model_path is None:
+    raise parser.error("Using --inference requires --resume_model_path to be set.")
+
+env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=True, n_parallel=args.n_parallel,
+                              speedup=args.speedup)
 env = VecMonitor(env)
 
 if args.resume_model_path is None:

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -72,6 +72,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--inference",
+    default=False,
     action="store_true",
     help="Instead of training, it will run inference on a loaded model for --timesteps steps. "
          "Requires --resume_model_path to be set."


### PR DESCRIPTION
Adds the ability to save and load model for resuming training, run inference and save periodic checkpoints with CL arguments. 

Limitations of this implementation:
- While sb3 will save logs if starting multiple runs with the same experiment name by adding e.g. expname_1, expname_2 etc. to the folder name, my current checkpoint saving implementation requires a unique experiment dir or name argument to be set and prompts the user to set a different folder if the checkpoint folder exists, this is to prevent overwriting checkpoints from a previous run with the same experiment dir/name.

For example, if using the default arguments (no exp dir or name specified), the logs will be saved to:
`.\logs\sb3\Experiment_1`
and checkpoints will be saved to:
`.\logs\sb3\Experiment_checkpoints` 

- Resuming training does not keep track of previous timesteps in this implementation. So for example training with `--timesteps=10_000` and saving a model, then resuming training with the same setting and saving the model again will train the model for `20_000` total timesteps, but `10_000` steps will be displayed in the console log after the final training run.

This is just a draft implementation, I welcome your feedback on whether it is sufficient as specified before starting changes to the documentation. 