### PR TITLE
Fix rllib

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -76,6 +76,7 @@ jobs:
         pip install .[test]
     - name: Clean up dependencies
       run: |
+        python -m pip install --upgrade pip
         pip uninstall -y stable-baselines3 gymnasium
         pip install .[rllib]
     - name: Download examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -73,7 +73,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # cpu version of pytorch
-        pip install .[test,rllib]
+        pip install .[rllib,test]
     - name: Download examples
       run: |
         make download_examples
@@ -97,7 +97,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # cpu version of pytorch
-        pip install .[test,rllib]
+        pip install .[rllib,test]
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -76,7 +76,6 @@ jobs:
         pip install .[test]
     - name: Clean up dependencies
       run: |
-        python -m pip install --upgrade pip
         pip uninstall -y stable-baselines3 gymnasium
         pip install .[rllib]
     - name: Download examples
@@ -100,11 +99,13 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel==0.38.4
         # cpu version of pytorch
         pip install .[test]
+    - name: Clean up dependencies
+      run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install ray[rllib]
+        pip install .[rllib]
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -75,7 +75,7 @@ jobs:
         # cpu version of pytorch
         pip install .[test]
         pip uninstall -y stable-baselines3 gymnasium
-        pip install -y ray[rllib]
+        pip install ray[rllib]
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -71,7 +71,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip wheel==0.38.4
         # cpu version of pytorch
         pip install .[test]
     - name: Clean up dependencies

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -73,7 +73,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # cpu version of pytorch
-        pip install .[rllib,test]
+        pip install .[test]
+        pip uninstall stable-baselines3 gymnasium
+        pip install ray[rllib]
     - name: Download examples
       run: |
         make download_examples
@@ -97,7 +99,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # cpu version of pytorch
-        pip install .[rllib,test]
+        pip install .[test]
+        pip uninstall stable-baselines3 gymnasium
+        pip install ray[rllib]
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -74,8 +74,8 @@ jobs:
         python -m pip install --upgrade pip
         # cpu version of pytorch
         pip install .[test]
-        pip uninstall stable-baselines3 gymnasium
-        pip install ray[rllib]
+        pip uninstall -y stable-baselines3 gymnasium
+        pip install -y ray[rllib]
     - name: Download examples
       run: |
         make download_examples
@@ -100,8 +100,8 @@ jobs:
         python -m pip install --upgrade pip
         # cpu version of pytorch
         pip install .[test]
-        pip uninstall stable-baselines3 gymnasium
-        pip install ray[rllib]
+        pip uninstall -y stable-baselines3 gymnasium
+        pip install -y ray[rllib]
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -55,3 +55,53 @@ jobs:
     - name: Test with pytest
       run: |
         make test
+
+
+  tests_ubuntu_rllib:
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10.10]
+        os: ['ubuntu-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # cpu version of pytorch
+        pip install .[test,rllib]
+    - name: Download examples
+      run: |
+        make download_examples
+
+    - name: Test with pytest
+      run: |
+        make test
+  tests_windows_rllib:
+    strategy:
+      matrix:
+        python-version: [3.8, 3.9, 3.10.10]
+        os: ['windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        # cpu version of pytorch
+        pip install .[test,rllib]
+    - name: Download examples
+      run: |
+        make download_examples
+
+    - name: Test with pytest
+      run: |
+        make test

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -101,7 +101,7 @@ jobs:
         # cpu version of pytorch
         pip install .[test]
         pip uninstall -y stable-baselines3 gymnasium
-        pip install -y ray[rllib]
+        pip install ray[rllib]
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Clean up dependencies
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install ray[rllib]
+        pip install .[rllib]
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -74,6 +74,8 @@ jobs:
         python -m pip install --upgrade pip
         # cpu version of pytorch
         pip install .[test]
+    - name: Clean up dependencies
+      run: |
         pip uninstall -y stable-baselines3 gymnasium
         pip install ray[rllib]
     - name: Download examples

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ dmypy.json
 
 envs/unity/
 logs/
+logs.*/
 dump/
 tmp/
 Packaging Python Projects — Python Packaging User Guide_files/

--- a/docs/ADV_CLEAN_RL.md
+++ b/docs/ADV_CLEAN_RL.md
@@ -17,11 +17,11 @@ You can read more about CleanRL in their [technical paper](https://arxiv.org/abs
 
 # Installation
 ```bash
-pip install godot-rl[clean-rl]
+pip install godot-rl[cleanrl]
 ```
 
-While the default options for clean-rl work reasonably well. You may be interested in changing the hyperparameters.
-We recommend taking the [clean-rl example](https://github.com/edbeeching/godot_rl_agents/blob/main/examples/clean_rl_example.py) and modifying to match your needs.
+While the default options for cleanrl work reasonably well. You may be interested in changing the hyperparameters.
+We recommend taking the [cleanrl example](https://github.com/edbeeching/godot_rl_agents/blob/main/examples/clean_rl_example.py) and modifying to match your needs.
 
 ```python
     parser.add_argument("--gae-lambda", type=float, default=0.95,

--- a/docs/ADV_RLLIB.md
+++ b/docs/ADV_RLLIB.md
@@ -5,7 +5,7 @@
 ## Installation
 
 If you want to train with rllib, create a new environment e.g.: `python -m venv venv.rllib` as rllib's dependencies can conflict with those of sb3 and other libraries.
-Due to a version clash with gymnasium, stable-baselines3 much be uninstalled before installing rllib.
+Due to a version clash with gymnasium, stable-baselines3 must be uninstalled before installing rllib.
 ```bash
 pip install godot-rl
 # remove sb3 and gymnasium installations

--- a/docs/ADV_RLLIB.md
+++ b/docs/ADV_RLLIB.md
@@ -4,6 +4,8 @@
 
 ## Installation
 
+If you want to train with rllib, create a new environment e.g.: `python -m venv venv.rllib` as rllib's dependencies can conflict with those of sb3 and other libraries.
+
 ```bash
 # remove sb3 installation with pip uninstall godot-rl[sb3]
 pip install godot-rl[rllib]

--- a/docs/ADV_RLLIB.md
+++ b/docs/ADV_RLLIB.md
@@ -5,10 +5,13 @@
 ## Installation
 
 If you want to train with rllib, create a new environment e.g.: `python -m venv venv.rllib` as rllib's dependencies can conflict with those of sb3 and other libraries.
-
+Due to a version clash with gymnasium, stable-baselines3 much be uninstalled before installing rllib.
 ```bash
-# remove sb3 installation with pip uninstall godot-rl[sb3]
-pip install godot-rl[rllib]
+pip install godot-rl
+# remove sb3 and gymnasium installations
+pip uninstall -y stable-baselines3 gymnasium
+# install rllib
+pip install ray[rllib]
 ```
 
 ## Basic Environment Usage

--- a/examples/clean_rl_example.py
+++ b/examples/clean_rl_example.py
@@ -16,6 +16,9 @@ from godot_rl.wrappers.clean_rl_wrapper import CleanRLGodotEnv
 def parse_args():
     # fmt: off
     parser = argparse.ArgumentParser()
+    parser.add_argument("--viz", default=False, type=bool,
+        help="If set, the simulation will be displayed in a window during training. Otherwise "
+            "training will run without rendering the simualtion. This setting does not apply to in-editor training.")
     parser.add_argument("--experiment_dir", default="logs/cleanrl", type=str,
         help="The name of the experiment directory, in which the tensorboard logs are getting stored")
     parser.add_argument("--experiment_name", default=os.path.basename(__file__).rstrip(".py"), type=str,
@@ -154,7 +157,7 @@ if __name__ == "__main__":
 
     # env setup
     
-    envs = env = CleanRLGodotEnv(env_path=args.env_path, show_window=True, speedup=args.speedup, convert_action_space=True) # Godot envs are already vectorized
+    envs = env = CleanRLGodotEnv(env_path=args.env_path, show_window=args.viz, speedup=args.speedup, convert_action_space=True) # Godot envs are already vectorized
     args.num_envs = envs.num_envs
     args.batch_size = int(args.num_envs * args.num_steps)
     args.minibatch_size = int(args.batch_size // args.num_minibatches)

--- a/examples/clean_rl_example.py
+++ b/examples/clean_rl_example.py
@@ -5,7 +5,6 @@ import random
 import time
 from distutils.util import strtobool
 from collections import deque
-import gym
 import numpy as np
 import torch
 import torch.nn as nn
@@ -156,7 +155,6 @@ if __name__ == "__main__":
     # env setup
     
     envs = env = CleanRLGodotEnv(env_path=args.env_path, show_window=True, speedup=args.speedup, convert_action_space=True) # Godot envs are already vectorized
-    #assert isinstance(envs.single_action_space, gym.spaces.Box), "only continuous action space is supported"
     args.num_envs = envs.num_envs
     args.batch_size = int(args.num_envs * args.num_steps)
     args.minibatch_size = int(args.batch_size // args.num_minibatches)

--- a/examples/sample_factory_example.py
+++ b/examples/sample_factory_example.py
@@ -12,6 +12,12 @@ def get_args():
     parser.add_argument("--viz", default=False, action="store_true", help="Whether to visualize one process")
     parser.add_argument("--experiment_dir", default="logs/sf", type=str,
     help="The name of the experiment directory, in which the tensorboard logs are getting stored")
+    parser.add_argument(
+        "--experiment_name",
+        default="experiment",
+        type=str,
+        help="The name of the experiment, which will be displayed in tensorboard. ",
+    )
 
     return parser.parse_known_args()
 

--- a/examples/sample_factory_example.py
+++ b/examples/sample_factory_example.py
@@ -7,7 +7,8 @@ def get_args():
     parser.add_argument("--env_path", default=None, type=str, help="Godot binary to use")
     parser.add_argument("--eval", default=False, action="store_true", help="whether to eval the model")
     parser.add_argument("--speedup", default=1, type=int, help="whether to speed up the physics in the env")
-    parser.add_argument("--export", default=False, action="store_true", help="wheter to export the model")
+    parser.add_argument("--seed", default=0, type=int, help="environment seed")
+    parser.add_argument("--export", default=False, action="store_true", help="whether to export the model")
     parser.add_argument("--viz", default=False, action="store_true", help="Whether to visualize one process")
 
     return parser.parse_known_args()

--- a/examples/sample_factory_example.py
+++ b/examples/sample_factory_example.py
@@ -10,6 +10,8 @@ def get_args():
     parser.add_argument("--seed", default=0, type=int, help="environment seed")
     parser.add_argument("--export", default=False, action="store_true", help="whether to export the model")
     parser.add_argument("--viz", default=False, action="store_true", help="Whether to visualize one process")
+    parser.add_argument("--experiment_dir", default="logs/sf", type=str,
+    help="The name of the experiment directory, in which the tensorboard logs are getting stored")
 
     return parser.parse_known_args()
 

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -82,8 +82,8 @@ parser.add_argument(
 parser.add_argument(
     "--viz",
     action="store_true",
-    help="If set, the window(s) with the Godot environment(s) will be displayed, otherwise "
-         "training will run without rendering the game. Does not apply to in-editor training.",
+    help="If set, the simulation will be displayed in a window during training. Otherwise "
+        "training will run without rendering the simualtion. This setting does not apply to in-editor training.",
     default=False
 )
 parser.add_argument("--speedup", default=1, type=int, help="Whether to speed up the physics in the env")

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 
 from stable_baselines3.common.callbacks import CheckpointCallback
+from godot_rl.core.utils import can_import
 from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
 from godot_rl.wrappers.onnx.stable_baselines_export import export_ppo_model_as_onnx
 from stable_baselines3 import PPO
@@ -11,7 +12,8 @@ from stable_baselines3.common.vec_env.vec_monitor import VecMonitor
 # To download the env source and binary:
 # 1.  gdrl.env_from_hub -r edbeeching/godot_rl_BallChase
 # 2.  chmod +x examples/godot_rl_BallChase/bin/BallChase.x86_64
-
+if can_import("ray"):
+    print("WARNING, stable baselines and ray[rllib] are not compatable")
 
 parser = argparse.ArgumentParser(allow_abbrev=False)
 parser.add_argument(

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -37,6 +37,12 @@ parser.add_argument(
          "for checkpoint directory and name (if enabled).",
 )
 parser.add_argument(
+    "--seed",
+    type=int,
+    default=0,
+    help="seed of the experiment"
+)
+parser.add_argument(
     "--resume_model_path",
     default=None,
     type=str,
@@ -107,7 +113,7 @@ if args.inference and args.resume_model_path is None:
 if args.env_path is None and args.viz:
     print("Info: Using --viz without --env_path set has no effect, in-editor training will always render.")
 
-env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=args.viz, n_parallel=args.n_parallel,
+env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=args.viz, seed=args.seed, n_parallel=args.n_parallel,
                               speedup=args.speedup)
 env = VecMonitor(env)
 

--- a/examples/stable_baselines3_hp_tuning.py
+++ b/examples/stable_baselines3_hp_tuning.py
@@ -23,7 +23,7 @@ except ImportError as e:
 from typing import Any
 from typing import Dict
 
-import gym
+import gymnasium as gym
 
 from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
 from godot_rl.core.godot_env import GodotEnv

--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -225,7 +225,7 @@ class GodotEnv:
         response["obs"] = self._process_obs(response["obs"])
         assert response["type"] == "reset"
         obs = response["obs"]
-        return obs, {}
+        return obs, [{}] * self.num_envs
 
     def call(self, method):
         message = {

--- a/godot_rl/main.py
+++ b/godot_rl/main.py
@@ -62,6 +62,7 @@ def get_args():
     parser.add_argument("--experiment_dir", default=None, type=str, help="The name of the the experiment directory, in which the tensorboard logs are getting stored")
     parser.add_argument("--experiment_name", default="experiment", type=str, help="The name of the the experiment, which will be displayed in tensborboard")
     parser.add_argument("--viz", default=False, action="store_true", help="Whether to visualize one process")
+    parser.add_argument("--seed", default=0, type=int, help="seed of the experiment")
     
     args, extras =  parser.parse_known_args()
     if args.experiment_dir is None:

--- a/godot_rl/wrappers/clean_rl_wrapper.py
+++ b/godot_rl/wrappers/clean_rl_wrapper.py
@@ -1,6 +1,6 @@
 
 import numpy as np
-import gym
+import gymnasium as gym
 from godot_rl.core.utils import lod_to_dol
 from godot_rl.core.godot_env import GodotEnv
 

--- a/godot_rl/wrappers/ray_wrapper.py
+++ b/godot_rl/wrappers/ray_wrapper.py
@@ -126,6 +126,8 @@ def rllib_training(args, extras):
     register_env()
 
     exp["config"]["env_config"]["env_path"] = args.env_path
+    exp["config"]["env_config"]["seed"] = args.seed
+
     if args.env_path is not None:
         run_name = exp["algorithm"] + "/" + pathlib.Path(args.env_path).stem
     else:

--- a/godot_rl/wrappers/ray_wrapper.py
+++ b/godot_rl/wrappers/ray_wrapper.py
@@ -47,7 +47,7 @@ class RayVectorGodotEnv(VectorEnv):
     def vector_step(
         self, actions: List[EnvActionType]
     ) -> Tuple[List[EnvObsType], List[float], List[bool], List[EnvInfoDict]]:
-        actions = np.array(actions)
+        actions = np.array(actions, dtype=np.dtype(object))
         self.obs, reward, term, trunc, info = self._env.step(actions, order_ij=True)
         return self.obs, reward, term, trunc, info
 

--- a/godot_rl/wrappers/sample_factory_wrapper.py
+++ b/godot_rl/wrappers/sample_factory_wrapper.py
@@ -72,32 +72,32 @@ class SampleFactoryEnvWrapperNonBatched(GodotEnv, Env):
         return
 
 
-def make_godot_env_func(env_path, full_env_name, cfg=None, env_config=None, render_mode=None, speedup=1, viz=False):
-    seed = 0
+def make_godot_env_func(env_path, full_env_name, cfg=None, env_config=None, render_mode=None, seed=0, speedup=1, viz=False):
     port = cfg.base_port
     print("BASE PORT ", cfg.base_port)
     show_window = False
+    _seed = seed
     if env_config:
         port += 1 + env_config.env_id
-        seed += 1 + env_config.env_id
+        _seed += 1 + env_config.env_id
         print("env id", env_config.env_id)
         if viz:  #
             print("creating viz env")
             show_window = env_config.env_id == 0
     if cfg.batched_sampling:
         env = SampleFactoryEnvWrapperBatched(
-            env_path=env_path, port=port, seed=seed, show_window=show_window, speedup=speedup
+            env_path=env_path, port=port, seed=_seed, show_window=show_window, speedup=speedup
         )
     else:
         env = SampleFactoryEnvWrapperNonBatched(
-            env_path=env_path, port=port, seed=seed, show_window=show_window, speedup=speedup
+            env_path=env_path, port=port, seed=_seed, show_window=show_window, speedup=speedup
         )
 
     return env
 
 
 def register_gdrl_env(args):
-    make_env = partial(make_godot_env_func, args.env_path, speedup=args.speedup, viz=args.viz)
+    make_env = partial(make_godot_env_func, args.env_path, speedup=args.speedup, seed=args.seed, viz=args.viz)
     register_env("gdrl", make_env)
 
 
@@ -152,6 +152,7 @@ def add_gdrl_env_args(_env, p: argparse.ArgumentParser, evaluation=False):
         # apparently env.render(mode="human") is not supported anymore and we need to specify the render mode in
         # the env actor
         p.add_argument("--render_mode", default="human", type=str, help="")
+
     p.add_argument("--base_port", default=GodotEnv.DEFAULT_PORT, type=int, help="")
 
     p.add_argument(

--- a/godot_rl/wrappers/sample_factory_wrapper.py
+++ b/godot_rl/wrappers/sample_factory_wrapper.py
@@ -161,26 +161,14 @@ def add_gdrl_env_args(_env, p: argparse.ArgumentParser, evaluation=False):
         type=int,
         help="Num agents in each envpool (if used)",
     )
-    p.add_argument(
-        "--experiment_dir",
-        default="logs/sf",
-        type=str,
-        help="The name of the experiment directory, in which the tensorboard logs are getting stored",
-    )
-    p.add_argument(
-        "--experiment_name",
-        default=None,
-        type=str,
-        help="The name of the experiment, which will be displayed in tensorboard",
-    )
 
 
-def parse_gdrl_args(argv=None, evaluation=False):
+def parse_gdrl_args(args, argv=None, evaluation=False):
     parser, partial_cfg = parse_sf_args(argv=argv, evaluation=evaluation)
     add_gdrl_env_args(partial_cfg.env, parser, evaluation=evaluation)
     gdrl_override_defaults(partial_cfg.env, parser)
     final_cfg = parse_full_cfg(parser, argv)
-    args, _ = parser.parse_known_args(argv)
+    
     final_cfg.train_dir = args.experiment_dir or "logs/sf"
     final_cfg.experiment = args.experiment_name or final_cfg.experiment
     return final_cfg
@@ -188,7 +176,7 @@ def parse_gdrl_args(argv=None, evaluation=False):
 
 def sample_factory_training(args, extras):
     register_gdrl_env(args)
-    cfg = parse_gdrl_args(argv=extras, evaluation=args.eval)
+    cfg = parse_gdrl_args(args=args, argv=extras, evaluation=args.eval)
     #cfg.base_port = random.randint(20000, 22000)
     status = run_rl(cfg)
     return status
@@ -196,7 +184,7 @@ def sample_factory_training(args, extras):
 
 def sample_factory_enjoy(args, extras):
     register_gdrl_env(args)
-    cfg = parse_gdrl_args(argv=extras, evaluation=args.eval)
+    cfg = parse_gdrl_args(args=args, argv=extras, evaluation=args.eval)
 
     status = enjoy(cfg)
     return status

--- a/godot_rl/wrappers/sample_factory_wrapper.py
+++ b/godot_rl/wrappers/sample_factory_wrapper.py
@@ -155,6 +155,8 @@ def add_gdrl_env_args(_env, p: argparse.ArgumentParser, evaluation=False):
 
     p.add_argument("--base_port", default=GodotEnv.DEFAULT_PORT, type=int, help="")
 
+    p.add_argument("--seed", default=0, type=int, help="")
+
     p.add_argument(
         "--env_agents",
         default=2,

--- a/godot_rl/wrappers/sample_factory_wrapper.py
+++ b/godot_rl/wrappers/sample_factory_wrapper.py
@@ -155,8 +155,6 @@ def add_gdrl_env_args(_env, p: argparse.ArgumentParser, evaluation=False):
 
     p.add_argument("--base_port", default=GodotEnv.DEFAULT_PORT, type=int, help="")
 
-    p.add_argument("--seed", default=0, type=int, help="")
-
     p.add_argument(
         "--env_agents",
         default=2,

--- a/godot_rl/wrappers/stable_baselines_wrapper.py
+++ b/godot_rl/wrappers/stable_baselines_wrapper.py
@@ -10,7 +10,7 @@ from godot_rl.core.utils import can_import, lod_to_dol
 
 
 class StableBaselinesGodotEnv(VecEnv):
-    def __init__(self, env_path: Optional[str] = None, n_parallel: int = 1, **kwargs) -> None:
+    def __init__(self, env_path: Optional[str] = None, n_parallel: int = 1, seed: int = 0, **kwargs) -> None:
         # If we are doing editor training, n_parallel must be 1
         if env_path is None and n_parallel > 1:
             raise ValueError("You must provide the path to a exported game executable if n_parallel > 1")
@@ -19,7 +19,7 @@ class StableBaselinesGodotEnv(VecEnv):
         port = kwargs.pop("port", GodotEnv.DEFAULT_PORT)
 
         # Create a list of GodotEnv instances
-        self.envs = [GodotEnv(env_path=env_path, convert_action_space=True, port=port+p, seed=p, **kwargs) for p in range(n_parallel)]
+        self.envs = [GodotEnv(env_path=env_path, convert_action_space=True, port=port+p, seed=seed+p, **kwargs) for p in range(n_parallel)]
         
         # Store the number of parallel environments
         self.n_parallel = n_parallel
@@ -114,7 +114,7 @@ class StableBaselinesGodotEnv(VecEnv):
             return [None for _ in range(self.num_envs)]
         raise AttributeError("get attr not fully implemented in godot-rl StableBaselinesWrapper")
 
-    def seed(self):
+    def seed(self, seed = None):
         raise NotImplementedError()
 
     def set_attr(self):

--- a/godot_rl/wrappers/stable_baselines_wrapper.py
+++ b/godot_rl/wrappers/stable_baselines_wrapper.py
@@ -6,7 +6,7 @@ from stable_baselines3.common.vec_env.vec_monitor import VecMonitor
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from godot_rl.core.godot_env import GodotEnv
-from godot_rl.core.utils import lod_to_dol
+from godot_rl.core.utils import can_import, lod_to_dol
 
 
 class StableBaselinesGodotEnv(VecEnv):
@@ -129,6 +129,8 @@ class StableBaselinesGodotEnv(VecEnv):
         return self.results
 
 def stable_baselines_training(args, extras, n_steps: int = 200000, **kwargs) -> None:
+    if can_import("ray"):
+        print("WARNING, stable baselines and ray[rllib] are not compatable")
     # Initialize the custom environment
     env = StableBaselinesGodotEnv(env_path=args.env_path, show_window=args.viz, speedup=args.speedup, **kwargs)
     env = VecMonitor(env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
 [project]
 name = "godot_rl"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
   { name="Edward Beeching", email="edbeeching@gmail.com" },
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,17 +48,9 @@ sf =
     sample-factory
 
 rllib = 
-    numpy==1.23.5
-    ray==2.2.0
+    gymnasium==0.26.3
     ray[rllib]
-    tensorflow_probability
 
 clean-rl = 
     wandb
 
-all =     
-    numpy==1.23.5
-    sample-factory
-    ray==2.2.0
-    ray[rllib]
-    tensorflow_probability

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,6 +51,6 @@ rllib =
     gymnasium==0.26.3
     ray[rllib]
 
-clean-rl = 
+cleanrl = 
     wandb
 

--- a/tests/fixtures/test_rllib.yaml
+++ b/tests/fixtures/test_rllib.yaml
@@ -1,0 +1,39 @@
+
+algorithm: PPO
+
+stop:
+    episode_reward_mean: 5000
+    training_iteration: 1000
+    timesteps_total: 200
+
+config:
+    env: godot
+    env_config:
+        framerate: null
+        action_repeat: null
+        show_window: false
+        seed: 0
+    framework: torch  
+    lambda: 0.95
+    gamma: 0.95
+
+    vf_clip_param: 1.0
+    clip_param: 0.2
+    entropy_coeff: 0.001
+    entropy_coeff_schedule: null
+    train_batch_size: 1024
+    sgd_minibatch_size: 128
+    num_sgd_iter: 16
+    num_workers: 4
+    lr: 0.0003
+    num_envs_per_worker: 16
+    batch_mode: truncate_episodes
+    rollout_fragment_length: 16
+    num_gpus: 1
+    model:
+        fcnet_hiddens: [256, 256] 
+        use_lstm: false
+        lstm_cell_size : 32
+        framestack: 4
+    no_done_at_end: false
+    soft_horizon: false

--- a/tests/fixtures/test_rllib.yaml
+++ b/tests/fixtures/test_rllib.yaml
@@ -4,7 +4,7 @@ algorithm: PPO
 stop:
     episode_reward_mean: 5000
     training_iteration: 1000
-    timesteps_total: 200
+    timesteps_total: 100
 
 config:
     env: godot
@@ -24,7 +24,7 @@ config:
     train_batch_size: 1024
     sgd_minibatch_size: 128
     num_sgd_iter: 16
-    num_workers: 4
+    num_workers: 1
     lr: 0.0003
     num_envs_per_worker: 16
     batch_mode: truncate_episodes

--- a/tests/test_rllib.py
+++ b/tests/test_rllib.py
@@ -1,0 +1,14 @@
+import pytest
+
+from godot_rl.core.utils import cant_import
+
+@pytest.mark.skipif(cant_import("ray"), reason="ray[rllib] is not available")
+def test_rllib_training():
+    from godot_rl.wrappers.ray_wrapper import rllib_training
+    from godot_rl.main import get_args
+    args, extras = get_args()
+    args.config_file = "tests/fixtures/test_rllib.yaml"
+    args.env_path = "examples/godot_rl_JumperHard/bin/JumperHard.x86_64"
+
+    
+    rllib_training(args, extras)

--- a/tests/test_sample_factory.py
+++ b/tests/test_sample_factory.py
@@ -14,3 +14,4 @@ def test_sample_factory_training():
     extras.append('--device=cpu')
     
     sample_factory_training(args, extras)
+    

--- a/tests/test_sb3_onnx_export.py
+++ b/tests/test_sb3_onnx_export.py
@@ -1,13 +1,10 @@
 import os
 
 import pytest
-from stable_baselines3 import PPO
 
-from godot_rl.wrappers.onnx.stable_baselines_export import (
-    export_ppo_model_as_onnx, verify_onnx_export)
-from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
+from godot_rl.core.utils import can_import
 
-
+@pytest.mark.skipif(can_import("ray"), reason="rllib and sb3 are not compatable")
 @pytest.mark.parametrize(
     "env_name,port",
     [
@@ -19,6 +16,10 @@ from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
     ],
 )
 def test_pytorch_vs_onnx(env_name, port):
+    from stable_baselines3 import PPO
+    from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
+    from godot_rl.wrappers.onnx.stable_baselines_export import export_ppo_model_as_onnx, verify_onnx_export
+    
     env_path = f"examples/godot_rl_{env_name}/bin/{env_name}.x86_64"
     env = StableBaselinesGodotEnv(env_path, port=port)
 

--- a/tests/test_sb3_training.py
+++ b/tests/test_sb3_training.py
@@ -1,15 +1,9 @@
 import pytest
 
-from godot_rl.core.godot_env import GodotEnv
 from godot_rl.main import get_args
+from godot_rl.core.utils import can_import
 
-try:
-    from godot_rl.wrappers.stable_baselines_wrapper import stable_baselines_training
-except ImportError as e:
-
-    def stable_baselines_training(args, extras, **kwargs):
-        print("Import error when trying to use sb3, this is probably not installed try pip install godot-rl[sb3]")
-
+@pytest.mark.skipif(can_import("ray"), reason="rllib and sb3 are not compatable")
 @pytest.mark.parametrize(
     "env_name,port",
     [
@@ -20,13 +14,9 @@ except ImportError as e:
         ("FlyBy", 12400),
     ],
 )
-@pytest.mark.parametrize(
-    "n_parallel",[
-        1,2,4
-    ]
-    
-)
+@pytest.mark.parametrize("n_parallel",[1,2,4])
 def test_sb3_training(env_name, port, n_parallel):
+    from godot_rl.wrappers.stable_baselines_wrapper import stable_baselines_training
     args, extras = get_args()
     args.env = "gdrl"
     args.env_path = f"examples/godot_rl_{env_name}/bin/{env_name}.x86_64"


### PR DESCRIPTION
Should resolve #139 

- Updates RLLIB wrappers to support latest version.
- Updates setup to install correct version of gymnasium for rllib
- Make cleanrl work again (use gymnasium instead of gym)
- Make hp tuning work again (use gymnasium instead of gym)

Needs install from new venv with `pip install godot-rl[rllib]`