### PR TITLE
Ray 2.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ dmypy.json
 
 envs/unity/
 logs/
+logs.*/
 dump/
 tmp/
 Packaging Python Projects — Python Packaging User Guide_files/

--- a/docs/ADV_CLEAN_RL.md
+++ b/docs/ADV_CLEAN_RL.md
@@ -17,11 +17,11 @@ You can read more about CleanRL in their [technical paper](https://arxiv.org/abs
 
 # Installation
 ```bash
-pip install godot-rl[clean-rl]
+pip install godot-rl[cleanrl]
 ```
 
-While the default options for clean-rl work reasonably well. You may be interested in changing the hyperparameters.
-We recommend taking the [clean-rl example](https://github.com/edbeeching/godot_rl_agents/blob/main/examples/clean_rl_example.py) and modifying to match your needs.
+While the default options for cleanrl work reasonably well. You may be interested in changing the hyperparameters.
+We recommend taking the [cleanrl example](https://github.com/edbeeching/godot_rl_agents/blob/main/examples/clean_rl_example.py) and modifying to match your needs.
 
 ```python
     parser.add_argument("--gae-lambda", type=float, default=0.95,

--- a/docs/ADV_RLLIB.md
+++ b/docs/ADV_RLLIB.md
@@ -4,6 +4,8 @@
 
 ## Installation
 
+If you want to train with rllib, create a new environment e.g.: `python -m venv venv.rllib` as rllib's dependencies can conflict with those of sb3 and other libraries.
+
 ```bash
 # remove sb3 installation with pip uninstall godot-rl[sb3]
 pip install godot-rl[rllib]

--- a/godot_rl/wrappers/ray_wrapper.py
+++ b/godot_rl/wrappers/ray_wrapper.py
@@ -45,7 +45,7 @@ class RayVectorGodotEnv(VectorEnv):
     def vector_step(
         self, actions: List[EnvActionType]
     ) -> Tuple[List[EnvObsType], List[float], List[bool], List[EnvInfoDict]]:
-        actions = np.array(actions)
+        actions = np.array(actions, dtype=np.dtype(object))
         self.obs, reward, term, trunc, info = self._env.step(actions, order_ij=True)
         return self.obs, reward, term, trunc, info
 

--- a/godot_rl/wrappers/ray_wrapper.py
+++ b/godot_rl/wrappers/ray_wrapper.py
@@ -31,30 +31,35 @@ class RayVectorGodotEnv(VectorEnv):
             show_window=show_window,
             framerate=framerate,
             action_repeat=action_repeat,
-        )
+        )        
         super().__init__(
             observation_space=self._env.observation_space,
             action_space=self._env.action_space,
             num_envs=self._env.num_envs,
         )
 
-    def vector_reset(self) -> List[EnvObsType]:
+    def vector_reset(self, seeds = None, options = None) -> List[EnvObsType]:    
         obs, info = self._env.reset()
-        return obs
+        return obs, ([info] * self.num_envs)
 
     def vector_step(
         self, actions: List[EnvActionType]
     ) -> Tuple[List[EnvObsType], List[float], List[bool], List[EnvInfoDict]]:
         actions = np.array(actions)
         self.obs, reward, term, trunc, info = self._env.step(actions, order_ij=True)
-        return self.obs, reward, term, info
+        return self.obs, reward, term, trunc, info
 
     def get_unwrapped(self):
         return [self._env]
 
-    def reset_at(self, index: Optional[int]) -> EnvObsType:
+    def reset_at(self, index: Optional[int], seed = None, options = None) -> EnvObsType:
         # the env is reset automatically, no need to reset it
-        return self.obs[index]
+        if hasattr(self, "obs"):
+            return self.obs[index], {}
+        else:
+            # First Reset
+            obs, info = self._env.reset()
+            return obs[index], info
 
 
 def register_env():

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     wget
     huggingface_hub>=0.10
     gymnasium
-    stable-baselines3
+    stable-baselines3>=2.0.0
     huggingface_sb3
     onnx
     onnxruntime
@@ -47,18 +47,10 @@ dev =
 sf =
     sample-factory
 
-rllib = 
+rllib =
     numpy==1.23.5
-    ray==2.2.0
-    ray[rllib]
-    tensorflow_probability
+    ray==2.6.0
+    ray[rllib]==2.6.0
 
-clean-rl = 
+cleanrl = 
     wandb
-
-all =     
-    numpy==1.23.5
-    sample-factory
-    ray==2.2.0
-    ray[rllib]
-    tensorflow_probability

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     wget
     huggingface_hub>=0.10
     gymnasium
-    stable-baselines3>=2.0.0
+    stable-baselines3
     huggingface_sb3
     onnx
     onnxruntime
@@ -47,10 +47,10 @@ dev =
 sf =
     sample-factory
 
-rllib =
-    numpy==1.23.5
-    ray==2.6.0
-    ray[rllib]==2.6.0
+rllib = 
+    gymnasium==0.26.3
+    ray[rllib]
 
 cleanrl = 
     wandb
+


### PR DESCRIPTION
- updated ray to 2.0.6 and remove `pip install godotrl[all]` command, as ray and sb3 dependencies conflict with each other.