### PR TITLE
Require sb3 version 2 or newer

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -77,6 +77,7 @@ jobs:
     - name: Clean up dependencies
       run: |
         pip uninstall -y stable-baselines3 gymnasium
+        pip install gymnasium==0.26.3
         pip install ray[rllib]
     - name: Download examples
       run: |
@@ -105,6 +106,7 @@ jobs:
     - name: Clean up dependencies
       run: |
         pip uninstall -y stable-baselines3 gymnasium
+        pip install gymnasium==0.26.3
         pip install ray[rllib]
     - name: Download examples
       run: |

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Clean up dependencies
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install .[rllib]
+        pip install ray[rllib]
     - name: Download examples
       run: |
         make download_examples
@@ -105,7 +105,7 @@ jobs:
     - name: Clean up dependencies
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install .[rllib]
+        pip install ray[rllib]
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -77,7 +77,6 @@ jobs:
     - name: Clean up dependencies
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install gymnasium==0.26.3
         pip install ray[rllib]
     - name: Download examples
       run: |
@@ -106,7 +105,6 @@ jobs:
     - name: Clean up dependencies
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install gymnasium==0.26.3
         pip install ray[rllib]
     - name: Download examples
       run: |

--- a/godot_rl/main.py
+++ b/godot_rl/main.py
@@ -21,7 +21,6 @@ gdrl --env_path path/to/exported/executable ---config_path path/to/yaml/file
 """
 
 import argparse
-import os
 
 try:
     from godot_rl.wrappers.ray_wrapper import rllib_training

--- a/godot_rl/main.py
+++ b/godot_rl/main.py
@@ -21,6 +21,7 @@ gdrl --env_path path/to/exported/executable ---config_path path/to/yaml/file
 """
 
 import argparse
+import os
 
 try:
     from godot_rl.wrappers.ray_wrapper import rllib_training

--- a/godot_rl/wrappers/onnx/stable_baselines_export.py
+++ b/godot_rl/wrappers/onnx/stable_baselines_export.py
@@ -59,7 +59,7 @@ def verify_onnx_export(ppo: PPO, onnx_model_path: str, num_tests=10):
     onnx.checker.check_model(onnx_model)
 
     sb3_model = ppo.policy.to("cpu")
-    ort_sess = ort.InferenceSession(onnx_model_path)
+    ort_sess = ort.InferenceSession(onnx_model_path, providers=['CPUExecutionProvider'])
 
     for i in range(num_tests):
         obs = dict(ppo.observation_space.sample())

--- a/godot_rl/wrappers/ray_wrapper.py
+++ b/godot_rl/wrappers/ray_wrapper.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from typing import Callable, List, Optional, Tuple
 
@@ -174,7 +175,7 @@ def rllib_training(args, extras):
         checkpoint_freq=checkpoint_freq,
         checkpoint_at_end=not args.eval,
         restore=args.restore,
-        local_dir=args.experiment_dir or "logs/rllib",
+        local_dir=os.path.abspath(args.experiment_dir) or os.path.abspath("logs/rllib"),
         trial_name_creator=lambda trial: f"{args.experiment_name}" if args.experiment_name else f"{trial.trainable_name}_{trial.trial_id}"
     )
     if args.export:

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,6 @@ sf =
     sample-factory
 
 rllib = 
-    gymnasium==0.26.3
     ray[rllib]
 
 cleanrl = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     wget
     huggingface_hub>=0.10
     gymnasium
-    stable-baselines3
+    stable-baselines3>=2.0.0
     huggingface_sb3
     onnx
     onnxruntime

--- a/tests/test_rllib.py
+++ b/tests/test_rllib.py
@@ -9,7 +9,7 @@ def test_rllib_training():
     from godot_rl.wrappers.ray_wrapper import rllib_training
     from godot_rl.main import get_args
     args, extras = get_args()
-    args.config_file = "fixtures/test_rllib.yaml"
+    args.config_file = "tests/fixtures/test_rllib.yaml"
     args.env_path = "examples/godot_rl_JumperHard/bin/JumperHard.x86_64"
 
     

--- a/tests/test_rllib.py
+++ b/tests/test_rllib.py
@@ -1,5 +1,3 @@
-import os.path
-
 import pytest
 
 from godot_rl.core.utils import cant_import

--- a/tests/test_rllib.py
+++ b/tests/test_rllib.py
@@ -1,3 +1,5 @@
+import os.path
+
 import pytest
 
 from godot_rl.core.utils import cant_import
@@ -7,7 +9,7 @@ def test_rllib_training():
     from godot_rl.wrappers.ray_wrapper import rllib_training
     from godot_rl.main import get_args
     args, extras = get_args()
-    args.config_file = "tests/fixtures/test_rllib.yaml"
+    args.config_file = "fixtures/test_rllib.yaml"
     args.env_path = "examples/godot_rl_JumperHard/bin/JumperHard.x86_64"
 
     


### PR DESCRIPTION
Our environment will not work with older sb3 versions, due to using gymnasium (where older sb3 versions used gym). 

Edit: This may cause an issue with rllib, I will check the test results and see if it can be addressed if it does.