### PR TITLE
fix dtype of image data

### DIFF
--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -360,7 +360,6 @@ class GodotEnv:
         return (
             np.frombuffer(bytes.fromhex(hex_string), dtype=np.uint8)
             .reshape(shape)
-            .astype(np.float32)[:, :, :]  # TODO remove the alpha channel
         )
 
     def _send_as_json(self, dictionary):

--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -358,7 +358,7 @@ class GodotEnv:
         shape,
     ):
         return (
-            np.frombuffer(bytes.fromhex(hex_string), dtype=np.float16)
+            np.frombuffer(bytes.fromhex(hex_string), dtype=np.uint8)
             .reshape(shape)
             .astype(np.float32)[:, :, :]  # TODO remove the alpha channel
         )


### PR DESCRIPTION
Fix for handling image data received from Godot causing errors such as:
https://github.com/edbeeching/godot_rl_agents_examples/pull/14#issuecomment-1837311171

Tried with Godot 4.2, with training using `gdrl`.

With this and the plugin side fix, training should work.

Exporting to onnx is currently not supported, we could see if this can be addressed and how (may need the correct preprocessing) in future updates. Mixing image and vector data (multiple spaces) is untested.