### PR TITLE
Set sb3_imitation.py to CPU to fix error with CUDA

### DIFF
--- a/examples/sb3_imitation.py
+++ b/examples/sb3_imitation.py
@@ -177,7 +177,7 @@ learner = PPO(
     policy_kwargs=policy_kwargs,
     verbose=2,
     tensorboard_log=f"logs/{args.experiment_name}",
-    device="cpu"
+    device="cpu",
     # seed=args.seed // Not currently supported as stable_baselines_wrapper.py seed() method is not yet implemented.
 )
 
@@ -191,7 +191,7 @@ try:
             rng=rng,
             policy=learner.policy,
             custom_logger=logger,
-            device="cpu"
+            device="cpu",
         )
         print("Starting Imitation Learning Training using BC:")
         bc_trainer.train(n_epochs=args.bc_epochs)

--- a/examples/sb3_imitation.py
+++ b/examples/sb3_imitation.py
@@ -177,6 +177,7 @@ learner = PPO(
     policy_kwargs=policy_kwargs,
     verbose=2,
     tensorboard_log=f"logs/{args.experiment_name}",
+    device="cpu"
     # seed=args.seed // Not currently supported as stable_baselines_wrapper.py seed() method is not yet implemented.
 )
 
@@ -190,6 +191,7 @@ try:
             rng=rng,
             policy=learner.policy,
             custom_logger=logger,
+            device="cpu"
         )
         print("Starting Imitation Learning Training using BC:")
         bc_trainer.train(n_epochs=args.bc_epochs)


### PR DESCRIPTION
Set device to CPU as a temporary fix for CUDA users.

Thanks to @MichaelrMentele for reporting this issue and testing the solution.

Relevant PR to track (thanks to @JayRothenberger for finding it):
https://github.com/HumanCompatibleAI/imitation/pull/831
