### PR TITLE
Add sb3 sac onnx export

### DIFF
--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -8,7 +8,7 @@ from stable_baselines3.common.callbacks import CheckpointCallback
 from stable_baselines3.common.vec_env.vec_monitor import VecMonitor
 
 from godot_rl.core.utils import can_import
-from godot_rl.wrappers.onnx.stable_baselines_export import export_ppo_model_as_onnx
+from godot_rl.wrappers.onnx.stable_baselines_export import export_model_as_onnx
 from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
 
 # To download the env source and binary:
@@ -115,7 +115,7 @@ def handle_onnx_export():
     if args.onnx_export_path is not None:
         path_onnx = pathlib.Path(args.onnx_export_path).with_suffix(".onnx")
         print("Exporting onnx to: " + os.path.abspath(path_onnx))
-        export_ppo_model_as_onnx(model, str(path_onnx))
+        export_model_as_onnx(model, str(path_onnx))
 
 
 def handle_model_save():

--- a/tests/test_sb3_onnx_export.py
+++ b/tests/test_sb3_onnx_export.py
@@ -24,7 +24,7 @@ from godot_rl.core.utils import can_import
 def test_pytorch_vs_onnx(env_name, port):
     from stable_baselines3 import PPO
 
-    from godot_rl.wrappers.onnx.stable_baselines_export import export_ppo_model_as_onnx, verify_onnx_export
+    from godot_rl.wrappers.onnx.stable_baselines_export import export_model_as_onnx, verify_onnx_export
     from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
 
     env_path = f"examples/godot_rl_{env_name}/bin/{env_name}.x86_64"
@@ -39,6 +39,6 @@ def test_pytorch_vs_onnx(env_name, port):
         tensorboard_log="logs/log",
     )
 
-    export_ppo_model_as_onnx(ppo, f"{env_name}_tmp.onnx")
+    export_model_as_onnx(ppo, f"{env_name}_tmp.onnx")
     verify_onnx_export(ppo, f"{env_name}_tmp.onnx")
     os.remove(f"{env_name}_tmp.onnx")


### PR DESCRIPTION
This adds support for exporting SAC models with SB3. 
Support is added to the onnx export code.

To use, the model in SB3 example needs to be changed from PPO to SAC (for load as well if resume functionality is used), and single obs env should be used with MlpPolicy, e.g. as below:

```Python 
from godot_rl.wrappers.sbg_single_obs_wrapper import SBGSingleObsEnv
```
```Python
def handle_onnx_export():
    if args.onnx_export_path is not None:
        path_onnx = pathlib.Path(args.onnx_export_path).with_suffix(".onnx")
        print("Exporting onnx to: " + os.path.abspath(path_onnx))
        export_model_as_onnx(model, str(path_onnx), True) # Set to True when using single obs env with MlpPolicy (for both PPO and SAC)
```
```Python
env = SBGSingleObsEnv(
    env_path=args.env_path, show_window=args.viz, seed=args.seed, n_parallel=args.n_parallel, speedup=args.speedup
)
```
```Python
    model: SAC = SAC(
        "MlpPolicy",
        env,
        tensorboard_log=args.experiment_dir,
    )
```

Example video of running a trained onnx model on BallChase env, trained using SAC for ~1.7 hrs with 2 parallel envs and settings as below (the reward was also slightly changed):
```Python
    model: SAC = SAC(
        "MlpPolicy",
        env,
        gradient_steps=32,
        train_freq=32,
        verbose=2,
        learning_starts=250_000,
        tensorboard_log=args.experiment_dir,
    )
```
https://github.com/user-attachments/assets/de390e73-cef2-403d-8673-7614e4bcab5f