### PR TITLE
Deprecates the use of gdrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ You may need to add run permissions on the game executable.
 chmod +x examples/godot_rl_JumperHard/bin/JumperHard.x86_64
 ```
 
-Train and visualize
-
+Train and visualize, first download the [Stable Baselines 3 example](https://github.com/edbeeching/godot_rl_agents/blob/main/examples/stable_baselines3_example.py) script in the github repo:
 ```bash
+python examples/stable_baselines3_example.py --env_path=examples/godot_rl_JumperHard/bin/JumperHard.x86_64 --experiment_name=Experiment_01 --viz
+```
+
+Deprecated usage with an entrypoint (to be removed in version 1.0):
+```
 gdrl --env=gdrl --env_path=examples/godot_rl_JumperHard/bin/JumperHard.x86_64 --experiment_name=Experiment_01 --viz
 ```
 
@@ -54,7 +58,7 @@ You can also train an agent in the Godot editor, without the need to export the 
 
 1. Download the Godot 4 Game Engine from [https://godotengine.org/](https://godotengine.org/)
 2. Open the engine and import the JumperHard example in `examples/godot_rl_JumperHard`
-3. Start in editor training with: `gdrl`
+3. Start in editor training with: `python examples/stable_baselines3_example.py`
 
 ### Creating a custom environment
 

--- a/godot_rl/main.py
+++ b/godot_rl/main.py
@@ -94,10 +94,12 @@ def get_args():
     return args, extras
 
 
-
 def main():
-    warnings.warn("This use of gdrl is deprecated and will be removed in version 1.0, please refer to the examples in the github repo", DeprecationWarning)
-    
+    warnings.warn(
+        "This use of gdrl is deprecated and will be removed in version 1.0, please refer to the examples in the github repo",
+        DeprecationWarning,
+    )
+
     args, extras = get_args()
     if args.trainer == "rllib":
         training_function = rllib_training

--- a/godot_rl/main.py
+++ b/godot_rl/main.py
@@ -21,6 +21,7 @@ gdrl --env_path path/to/exported/executable ---config_path path/to/yaml/file
 """
 
 import argparse
+import warnings
 
 try:
     from godot_rl.wrappers.ray_wrapper import rllib_training
@@ -93,7 +94,10 @@ def get_args():
     return args, extras
 
 
+
 def main():
+    warnings.warn("This use of gdrl is deprecated and will be removed in version 1.0, please refer to the examples in the github repo", DeprecationWarning)
+    
     args, extras = get_args()
     if args.trainer == "rllib":
         training_function = rllib_training


### PR DESCRIPTION
Deprecates the use of `gdrl` to launch training in favor of examples. 
Discussed in #193 