### PR TITLE
Adds argument to set obs key to stable_baselines_export.py

### DIFF
--- a/godot_rl/wrappers/onnx/stable_baselines_export.py
+++ b/godot_rl/wrappers/onnx/stable_baselines_export.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import torch
 from gymnasium.vector.utils import spaces
 from stable_baselines3 import PPO, SAC

--- a/godot_rl/wrappers/onnx/stable_baselines_export.py
+++ b/godot_rl/wrappers/onnx/stable_baselines_export.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import torch
 from gymnasium.vector.utils import spaces
 from stable_baselines3 import PPO, SAC
@@ -45,7 +47,7 @@ class OnnxablePolicy(torch.nn.Module):
             return self.forward_ppo(obs, state_ins)
 
 
-def export_model_as_onnx(model, onnx_model_path: str, use_obs_array: bool = False):
+def export_model_as_onnx(model, onnx_model_path: str, use_obs_array: bool = False, obs_keys: List[str] = "obs"):
     policy = model.policy.to("cpu")
     dummy_input = None
     onnxable_model = None
@@ -55,7 +57,7 @@ def export_model_as_onnx(model, onnx_model_path: str, use_obs_array: bool = Fals
 
     if isinstance(model, PPO):
         onnxable_model = OnnxablePolicy(
-            ["obs"],
+            obs_keys,
             policy.features_extractor,
             policy.mlp_extractor,
             policy.action_net,

--- a/godot_rl/wrappers/onnx/stable_baselines_export.py
+++ b/godot_rl/wrappers/onnx/stable_baselines_export.py
@@ -47,7 +47,9 @@ class OnnxablePolicy(torch.nn.Module):
             return self.forward_ppo(obs, state_ins)
 
 
-def export_model_as_onnx(model, onnx_model_path: str, use_obs_array: bool = False, obs_keys: List[str] = "obs"):
+def export_model_as_onnx(model, onnx_model_path: str, use_obs_array: bool = False, obs_keys=None):
+    if obs_keys is None:
+        obs_keys = ["obs"]
     policy = model.policy.to("cpu")
     dummy_input = None
     onnxable_model = None


### PR DESCRIPTION
Adds the ability to change the obs key used when exporting to onnx.

### Usage:
1 - In SB3 example script, find `export_model_as_onnx` method, and inside it set the `obs_key`, e.g.:
```Python
export_model_as_onnx(model, str(path_onnx), obs_keys=['obs2'])
``` 
(recommended to use a single key for now, as that's what inference supports for now)

2 - In sync node in GDRL plugin in Godot, find the `_inference_process:` method and set the correct key, e.g.:
```Python
			var action = model.run_inference(
				obs[agent_id]["obs2"], 1.0
			)
```
(this should also be adjustable in the future for each agent, but as we support only one key, it's currently only necessary for the camera sensor so the Python server can detect it as image obs and run needed processing, in other cases there's no advantage from renaming the obs key)

> [!NOTE]
> If you don't set the key or modify anything, `obs` will be used by default as before. This is the default which all examples use. 

> [!NOTE]
> Onnx export/inference with the camera sensor is not guaranteed to work with this update. SB3/Rllib and other frameworks can do their own pre-processing which adds complexity to the implementation. However, this PR is still a required step toward it.