### PR TITLE
SB3 bugfix (limit max version)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,8 +15,8 @@ install_requires =
     tensorboard
     wget
     huggingface_hub>=0.10
-    gymnasium
-    stable-baselines3>=2.0.0
+    gymnasium<=0.29.1
+    stable-baselines3>=2.0.0,<2.4.0
     huggingface_sb3
     onnx
     onnxruntime


### PR DESCRIPTION
Fixes the SB3 error due to incompatibility with the newest version (temporarily, by limiting the max version - we should at some point update the code to support the newest gymnasium). 

Rllib issue is to be addressed separately. 