### PR TITLE
Limit Rllib version

### DIFF
--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Install Rllib
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install ray[rllib]<=2.38.0
+        pip install "ray[rllib]<=2.38.0"
     - name: Download examples
       run: |
         make download_examples
@@ -105,7 +105,7 @@ jobs:
     - name: Install Rllib
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install ray[rllib]<=2.38.0
+        pip install "ray[rllib]<=2.38.0"
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -78,6 +78,7 @@ jobs:
       run: |
         pip uninstall -y stable-baselines3 gymnasium
         pip install "ray[rllib]<=2.38.0"
+        pip install onnx==1.16.1
     - name: Download examples
       run: |
         make download_examples
@@ -106,6 +107,7 @@ jobs:
       run: |
         pip uninstall -y stable-baselines3 gymnasium
         pip install "ray[rllib]<=2.38.0"
+        pip install onnx==1.16.1
     - name: Download examples
       run: |
         make download_examples

--- a/.github/workflows/test-ci.yml
+++ b/.github/workflows/test-ci.yml
@@ -74,10 +74,10 @@ jobs:
         python -m pip install --upgrade pip wheel==0.38.4
         # cpu version of pytorch
         pip install .[test]
-    - name: Clean up dependencies
+    - name: Install Rllib
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install ray[rllib]
+        pip install ray[rllib]<=2.38.0
     - name: Download examples
       run: |
         make download_examples
@@ -102,10 +102,10 @@ jobs:
         python -m pip install --upgrade pip wheel==0.38.4
         # cpu version of pytorch
         pip install .[test]
-    - name: Clean up dependencies
+    - name: Install Rllib
       run: |
         pip uninstall -y stable-baselines3 gymnasium
-        pip install ray[rllib]
+        pip install ray[rllib]<=2.38.0
     - name: Download examples
       run: |
         make download_examples

--- a/docs/TRAINING_MULTIPLE_POLICIES.md
+++ b/docs/TRAINING_MULTIPLE_POLICIES.md
@@ -6,7 +6,7 @@ This is a brief guide on training multiple policies focusing on Rllib specifical
 
 `pip install https://github.com/edbeeching/godot_rl_agents/archive/refs/heads/main.zip` (to get the latest version)
 
-`pip install ray[rllib]`
+`pip install ray[rllib]<=2.38.0`
 
 `pip install PettingZoo`
 

--- a/docs/TRAINING_MULTIPLE_POLICIES.md
+++ b/docs/TRAINING_MULTIPLE_POLICIES.md
@@ -8,6 +8,8 @@ This is a brief guide on training multiple policies focusing on Rllib specifical
 
 `pip install ray[rllib]<=2.38.0`
 
+`pip install onnx==1.16.1`
+
 `pip install PettingZoo`
 
 ### Download the examples file and config file:


### PR DESCRIPTION
A temporary fix for Rllib, limits the version to a version that has passed tests previously.