### PR TITLE
onnx export: properly handle obs_keys

### DIFF
--- a/godot_rl/wrappers/onnx/stable_baselines_export.py
+++ b/godot_rl/wrappers/onnx/stable_baselines_export.py
@@ -81,10 +81,10 @@ def export_model_as_onnx(model, onnx_model_path: str, use_obs_array: bool = Fals
         args=(dummy_input, torch.zeros(1).float()),
         f=onnx_model_path,
         opset_version=17,
-        input_names=["obs", "state_ins"],
+        input_names=obs_keys + ["state_ins"],
         output_names=["output", "state_outs"],
         dynamic_axes={
-            "obs": {0: "batch_size"},
+            **{sub_obs: {0: "batch_size"} for sub_obs in obs_keys},
             "state_ins": {0: "batch_size"},  # variable length axes
             "output": {0: "batch_size"},
             "state_outs": {0: "batch_size"},

--- a/godot_rl/wrappers/onnx/stable_baselines_export.py
+++ b/godot_rl/wrappers/onnx/stable_baselines_export.py
@@ -119,6 +119,7 @@ def verify_onnx_export(ppo: PPO, onnx_model_path: str, num_tests=10, use_obs_arr
         if use_obs_array:
             obs = np.expand_dims(ppo.observation_space.sample(), axis=0)
             obs2 = torch.tensor(obs)
+            obs = {"obs": obs}
         else:
             obs_dict = dict(ppo.observation_space.sample())
             obs2 = {}


### PR DESCRIPTION
At the moment, the onnx export kinda ignores the passed observation keys and uses a hard coded "obs" at export. With these minor changes this is fixed and the onnx model has the properly named inputs set after export.

I viewed the exported model in Netron and ran an exported model in godot with the godot addon (I had to modify the add-on to not take the key "obs" for granted, probably will make a pull request for that later) to verify this modification works as intended.

Pls let me know if any further changes are necessary to get this merged.

Kind regards
Nico