### PR TITLE
Fix swapped action order in godot_env.py

### DIFF
--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -386,7 +386,9 @@ class GodotEnv:
                 else:
                     print(f"action space {v['action_type']} is not supported")
                     assert 0, f"action space {v['action_type']} is not supported"
-            self.action_spaces.append(spaces.Dict(tmp_action_spaces))
+            # Note: We're using list to avoid the keys getting sorted
+            tmp_action_spaces_list = list(tmp_action_spaces.items())
+            self.action_spaces.append(spaces.Dict(tmp_action_spaces_list))
 
         print("observation space", json_dict["observation_space"])
         # Compatibility with older versions of Godot plugin:


### PR DESCRIPTION
Should fix https://github.com/edbeeching/godot_rl_agents/issues/234

Action order gets sorted alphabetically by `spaces.Dict` when we give it a dictionary.
As a quick fix without changing other code sections, we convert the dictionary to list.

Still not properly tested for any issues that might be introduced, but it seems to preserve action order when using `print(env.action_space)`. Check the issue for more detail.

Edit:
Personally I only checked once with SB3 for now, will check a bit more (at least with SB3) when I can. Tests passed so hopefully other frameworks will work too. 

Seems to work OK in Godot after SB3 training too. We had a similar issue before, fixed by using an OrderedDict then, now as the issue has occurred again, using a list fixes it.