### PR TITLE
Allow passing custom commands to the executable environment

### DIFF
--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -22,7 +22,7 @@ parser.add_argument(
     "--env_path",
     default=None,
     type=str,
-    help="The Godot binary to use, do not include for in editor training",
+    help="The Godot binary to use, do not include for in-editor training",
 )
 parser.add_argument(
     "--experiment_dir",
@@ -138,6 +138,15 @@ def cleanup():
     handle_model_save()
     close_env()
 
+def parse_extras_into_kwargs(extras):
+    kwargs = {}
+    for extra in extras:
+        if not extra.strip():
+            continue
+        if (extra.startswith("--") or extra.startswith("-")) and "=" in extra:
+            key, value = extra.split("=", 1)
+            kwargs[key] = value
+    return kwargs
 
 path_checkpoint = os.path.join(args.experiment_dir, args.experiment_name + "_checkpoints")
 abs_path_checkpoint = os.path.abspath(path_checkpoint)
@@ -158,7 +167,12 @@ if args.env_path is None and args.viz:
     print("Info: Using --viz without --env_path set has no effect, in-editor training will always render.")
 
 env = StableBaselinesGodotEnv(
-    env_path=args.env_path, show_window=args.viz, seed=args.seed, n_parallel=args.n_parallel, speedup=args.speedup
+    env_path=args.env_path,
+    show_window=args.viz,
+    seed=args.seed,
+    n_parallel=args.n_parallel,
+    speedup=args.speedup,
+    **parse_extras_into_kwargs(extras),
 )
 env = VecMonitor(env)
 

--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -320,7 +320,7 @@ class GodotEnv:
             launch_cmd.append(f"--speedup={speedup}")
         if len(kwargs) > 0:
             for key, value in kwargs.items():
-                launch_cmd.append(f"--{key}={value}")
+                launch_cmd.append(f"{key}={value}")
 
         self.proc = subprocess.Popen(
             launch_cmd,


### PR DESCRIPTION
Fixes: GH-239


We can now passing the custom argument when we start training:
```
python stable_baselines3_example.py \
  --env_path /home/ubuntu/GodotProjects/my-project/builds/Linux/my-executable.sh --mode=Evaluation --control=Training \
  --save_model_path="/home/ubuntu/GodotProjects/my-project/my-project/onnx/pickup-flag" \
  --onnx_export_path="/home/ubuntu/GodotProjects/my-project/my-project/onnx/pickup-flag.onnx" \
  --save_checkpoint_frequency 10000 \
  --experiment_dir "/home/ubuntu/GodotProjects/my-project/my-project/logs/sb3" \
  --experiment_name "first-training" \
  --n_parallel 4
```

Here: `/home/ubuntu/GodotProjects/my-project/builds/Linux/my-executable.sh` is the path to executable file.
`--mode=Evaluation --control=Training` are two custom command which will be passed to the executable