### PR TITLE
Add action_repeat argument to SB3 example script

### DIFF
--- a/examples/sb3_imitation.py
+++ b/examples/sb3_imitation.py
@@ -237,10 +237,8 @@ try:
         print(f"Mean reward after evaluation: {mean_reward}")
 
 except (KeyboardInterrupt, ConnectionError, ConnectionResetError):
-    print(
-        """Training interrupted by user or a ConnectionError. Will save if --save_model_path was
-        used and/or export if --onnx_export_path was used."""
-    )
+    print("""Training interrupted by user or a ConnectionError. Will save if --save_model_path was
+        used and/or export if --onnx_export_path was used.""")
 
 finally:
     handle_onnx_export()

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -101,6 +101,12 @@ parser.add_argument(
 )
 parser.add_argument("--speedup", default=1, type=int, help="Whether to speed up the physics in the env")
 parser.add_argument(
+    "--action_repeat",
+    default=None,
+    type=int,
+    help="Similar concept to frame skip, sends action/gets obs every n frames only. Uses sync node setting if not set here.",
+)
+parser.add_argument(
     "--n_parallel",
     default=1,
     type=int,
@@ -158,7 +164,12 @@ if args.env_path is None and args.viz:
     print("Info: Using --viz without --env_path set has no effect, in-editor training will always render.")
 
 env = StableBaselinesGodotEnv(
-    env_path=args.env_path, show_window=args.viz, seed=args.seed, n_parallel=args.n_parallel, speedup=args.speedup
+    env_path=args.env_path,
+    show_window=args.viz,
+    seed=args.seed,
+    n_parallel=args.n_parallel,
+    speedup=args.speedup,
+    action_repeat=args.action_repeat,
 )
 env = VecMonitor(env)
 

--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -231,9 +231,7 @@ else:
     try:
         model.learn(**learn_arguments)
     except (KeyboardInterrupt, ConnectionError, ConnectionResetError):
-        print(
-            """Training interrupted by user or a ConnectionError. Will save if --save_model_path was
-            used and/or export if --onnx_export_path was used."""
-        )
+        print("""Training interrupted by user or a ConnectionError. Will save if --save_model_path was
+            used and/or export if --onnx_export_path was used.""")
     finally:
         cleanup()


### PR DESCRIPTION
Adds the action repeat option to the SB3 training example:

```python
parser.add_argument(
    "--action_repeat",
    default=None,
    type=int,
    help="Similar concept to frame skip, sends action/gets obs every n frames only. Uses sync node setting if not set here.",
)
```

Useful for more quickly comparing different `action repeat` settings without changing it in Godot, but that option remains.
This argument already exists in the Python Godot env, this PR just adds it to the SB3 script.