### PR TITLE
Clarify Python/onnx inference usage

### DIFF
--- a/docs/ADV_STABLE_BASELINES_3.md
+++ b/docs/ADV_STABLE_BASELINES_3.md
@@ -89,6 +89,9 @@ python stable_baselines3_example.py --timesteps=100_000 --onnx_export_path=model
 ```
 Note: If you interrupt/halt training using `ctrl + c`, it should save/export models before closing training (but only if you have included the corresponding arguments mentioned above). Using checkpoints (see below) is a safer way to keep progress.
 
+> [!NOTE]
+> For Python inference, the `Control Mode` in the Sync node in Godot Editor should be set to `Training`. Set `Onnx Inference` if you want to use the .onnx file without using the Python server (onnx inference uses C# instead).
+
 
 ### Resume training from a saved .zip model:
 This will load the previously saved model.zip, and resume training for another 100 000 steps, so the saved model will have been trained for 200 000 steps in total.
@@ -111,10 +114,12 @@ python stable_baselines3_example.py --experiment_name=experiment1 --timesteps=2_
 Checkpoints will be saved to `logs\sb3\experiment1_checkpoints` in the above case, the location is affected by `--experiment_dir` and `--experiment_name`.
 
 ### Run inference on a saved model for 100_000 steps:
-You can run inference on a model that was previously saved using either `--save_model_path` or `--save_checkpoint_frequency`.
+You can run Python inference on a model that was previously saved using either `--save_model_path` or `--save_checkpoint_frequency`.
 ```bash
 python stable_baselines3_example.py --timesteps=100_000 --resume_model_path=model.zip --inference
 ```
+> [!NOTE]
+> For Python inference, the `Control Mode` in the Sync node in Godot Editor should be set to `Training`. Set `Onnx Inference` if you want to use the .onnx file without using the Python server (onnx inference uses C# instead).
 
 ### Use a linear learning rate schedule:
 By default, the learning rate will be constant throughout training.

--- a/docs/ADV_STABLE_BASELINES_3.md
+++ b/docs/ADV_STABLE_BASELINES_3.md
@@ -92,7 +92,6 @@ Note: If you interrupt/halt training using `ctrl + c`, it should save/export mod
 > [!NOTE]
 > For Python inference, the `Control Mode` in the Sync node in Godot Editor should be set to `Training`. Set `Onnx Inference` if you want to use the .onnx file without using the Python server (onnx inference uses C# instead).
 
-
 ### Resume training from a saved .zip model:
 This will load the previously saved model.zip, and resume training for another 100 000 steps, so the saved model will have been trained for 200 000 steps in total.
 Note that the console log will display the `total_timesteps` for the last training session only, so it will show `100000` instead of `200000`. 
@@ -118,6 +117,7 @@ You can run Python inference on a model that was previously saved using either `
 ```bash
 python stable_baselines3_example.py --timesteps=100_000 --resume_model_path=model.zip --inference
 ```
+
 > [!NOTE]
 > For Python inference, the `Control Mode` in the Sync node in Godot Editor should be set to `Training`. Set `Onnx Inference` if you want to use the .onnx file without using the Python server (onnx inference uses C# instead).
 

--- a/docs/ADV_STABLE_BASELINES_3.md
+++ b/docs/ADV_STABLE_BASELINES_3.md
@@ -90,7 +90,7 @@ python stable_baselines3_example.py --timesteps=100_000 --onnx_export_path=model
 Note: If you interrupt/halt training using `ctrl + c`, it should save/export models before closing training (but only if you have included the corresponding arguments mentioned above). Using checkpoints (see below) is a safer way to keep progress.
 
 > [!NOTE]
-> For Python inference, the `Control Mode` in the Sync node in Godot Editor should be set to `Training`. Set `Onnx Inference` if you want to use the .onnx file without using the Python server (onnx inference uses C# instead).
+> For Python inference, the `Control Mode` in the Sync node in Godot Editor should be set to `Training`. Set `Onnx Inference` if you want to run inference in Godot without Python (this mode uses C# instead).
 
 ### Resume training from a saved .zip model:
 This will load the previously saved model.zip, and resume training for another 100 000 steps, so the saved model will have been trained for 200 000 steps in total.
@@ -119,7 +119,7 @@ python stable_baselines3_example.py --timesteps=100_000 --resume_model_path=mode
 ```
 
 > [!NOTE]
-> For Python inference, the `Control Mode` in the Sync node in Godot Editor should be set to `Training`. Set `Onnx Inference` if you want to use the .onnx file without using the Python server (onnx inference uses C# instead).
+> For Python inference, the `Control Mode` in the Sync node in Godot Editor should be set to `Training`. Set `Onnx Inference` if you want to run inference in Godot without Python (this mode uses C# instead).
 
 ### Use a linear learning rate schedule:
 By default, the learning rate will be constant throughout training.

--- a/docs/NODE_REFERENCE.md
+++ b/docs/NODE_REFERENCE.md
@@ -72,14 +72,13 @@ This is the main node that controls training and inference (using the trained mo
 
 There are three modes:
 
-- Training - will start training when you click `Play` in Godot editor (or use the exported application as `--env_path`
-  in training).
+- Training - After you start the Python training script, will start training when you click `Play` in Godot editor (or you can use the exported application as `--env_path` for training). This mode is also used for Python based inference of a saved model.
 
 > [!NOTE]
 > For training to work, you need
 > to [install Godot-RL](https://github.com/edbeeching/godot_rl_agents#installation-and-first-training) and start the
-> training server using `gdrl`, or, to have the ability to save the model after training is done, using
-> the [sb3 example script](https://github.com/edbeeching/godot_rl_agents/blob/main/docs/ADV_STABLE_BASELINES_3.md#sb3-example-script-usage).
+> training server using the [sb3 example script](https://github.com/edbeeching/godot_rl_agents/blob/main/docs/ADV_STABLE_BASELINES_3.md#sb3-example-script-usage) -
+> check the link also for how to save/export a model for Python or ONNX inference.
 
 - Human - `ai_controller.heuristic` will be set to `"human"`. You can use this to test the environment by manually
   controlling the agent, e.g. as implemented in


### PR DESCRIPTION
Clarified instructions for which Sync node mode to select when using Python based vs ONNX inference. Partially addresses https://github.com/edbeeching/godot_rl_agents_plugin/issues/69.