### PR TITLE
Pass --fixed-fps as two argv tokens

### DIFF
--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -7,7 +7,7 @@ import subprocess
 import time
 from collections import OrderedDict
 from sys import platform
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 from gymnasium import spaces
@@ -291,6 +291,43 @@ class GodotEnv:
         print("exit was not clean, using atexit to close env")
         self.close()
 
+    @staticmethod
+    def _build_launch_cmd(
+        env_path,
+        port,
+        show_window,
+        framerate,
+        seed,
+        action_repeat,
+        speedup,
+        **kwargs,
+    ) -> List[str]:
+        """Build the argv list used to launch the Godot game.
+
+        Kept separate from the actual launch so it can be unit tested without a game binary.
+        """
+        path = convert_macos_path(env_path) if platform == "darwin" else env_path
+
+        launch_cmd = [path]
+        launch_cmd.append(f"--port={port}")
+        launch_cmd.append(f"--env_seed={seed}")
+
+        if show_window is False:
+            launch_cmd.append("--disable-render-loop")
+            launch_cmd.append("--headless")
+        if framerate is not None:
+            # --fixed-fps is a Godot engine argument, it expects its value as a separate token
+            launch_cmd.extend(["--fixed-fps", str(framerate)])
+        if action_repeat is not None:
+            launch_cmd.append(f"--action_repeat={action_repeat}")
+        if speedup is not None:
+            launch_cmd.append(f"--speedup={speedup}")
+        if len(kwargs) > 0:
+            for key, value in kwargs.items():
+                launch_cmd.append(f"--{key}={value}")
+
+        return launch_cmd
+
     def _launch_env(
         self,
         env_path,
@@ -302,25 +339,16 @@ class GodotEnv:
         speedup,
         **kwargs,
     ):
-        # --fixed-fps {framerate}
-        path = convert_macos_path(env_path) if platform == "darwin" else env_path
-
-        launch_cmd = [path]
-        launch_cmd.append(f"--port={port}")
-        launch_cmd.append(f"--env_seed={seed}")
-
-        if show_window is False:
-            launch_cmd.append("--disable-render-loop")
-            launch_cmd.append("--headless")
-        if framerate is not None:
-            launch_cmd.append(f"--fixed-fps {framerate}")
-        if action_repeat is not None:
-            launch_cmd.append(f"--action_repeat={action_repeat}")
-        if speedup is not None:
-            launch_cmd.append(f"--speedup={speedup}")
-        if len(kwargs) > 0:
-            for key, value in kwargs.items():
-                launch_cmd.append(f"--{key}={value}")
+        launch_cmd = self._build_launch_cmd(
+            env_path,
+            port,
+            show_window,
+            framerate,
+            seed,
+            action_repeat,
+            speedup,
+            **kwargs,
+        )
 
         self.proc = subprocess.Popen(
             launch_cmd,

--- a/tests/test_launch_cmd.py
+++ b/tests/test_launch_cmd.py
@@ -1,0 +1,54 @@
+from godot_rl.core.godot_env import GodotEnv
+
+
+def build(**overrides):
+    kwargs = dict(
+        env_path="game.x86_64",
+        port=11008,
+        show_window=True,
+        framerate=None,
+        seed=0,
+        action_repeat=None,
+        speedup=None,
+    )
+    kwargs.update(overrides)
+    return GodotEnv._build_launch_cmd(**kwargs)
+
+
+def test_no_argument_carries_an_embedded_space():
+    # Popen receives argv as a list, so a token like "--fixed-fps 60" reaches Godot as a
+    # single unknown parameter and the engine aborts at startup.
+    cmd = build(framerate=60, action_repeat=4, speedup=8, show_window=False)
+    assert all(" " not in arg for arg in cmd[1:])
+
+
+def test_fixed_fps_is_split_into_two_tokens():
+    cmd = build(framerate=60)
+    assert "--fixed-fps" in cmd
+    assert cmd[cmd.index("--fixed-fps") + 1] == "60"
+
+
+def test_framerate_none_omits_the_flag():
+    assert not any("fixed-fps" in arg for arg in build())
+
+
+def test_plugin_arguments_keep_the_equals_form():
+    cmd = build(port=11010, seed=3, action_repeat=4, speedup=8)
+    assert "--port=11010" in cmd
+    assert "--env_seed=3" in cmd
+    assert "--action_repeat=4" in cmd
+    assert "--speedup=8" in cmd
+
+
+def test_hidden_window_adds_the_headless_flags():
+    cmd = build(show_window=False)
+    assert "--disable-render-loop" in cmd
+    assert "--headless" in cmd
+
+
+def test_extra_kwargs_are_forwarded():
+    assert "--custom_arg=7" in build(custom_arg=7)
+
+
+def test_env_path_stays_first():
+    assert build()[0] == "game.x86_64"


### PR DESCRIPTION
I have been building a personal project on top of godot-rl-agents, a harness that generates Godot games from text and trains a policy on each one to check it is actually solvable. Getting it to run at scale surfaced a handful of small bugs and rough edges in the library. This is the first of four PRs, all independent and small, mostly fixes and throughput things I needed. Happy to rework or drop any of them.

`--fixed-fps` is a Godot engine argument and expects its value as a separate token, but it is appended as one string:

```python
launch_cmd.append(f"--fixed-fps {framerate}")
```

`Popen` receives argv as a list, so Godot gets a single unknown parameter `--fixed-fps 60` rather than the flag and its value. On 4.7 the engine then gives up before starting the game:

```
$ Godot_v4.7-stable_linux.x86_64 --headless --path project --quit "--fixed-fps 60"
ERROR: Couldn't detect whether to run the editor, the project manager or a specific project. Aborting.

$ Godot_v4.7-stable_linux.x86_64 --headless --path project --quit --fixed-fps 60
(gets past argument parsing and runs the project)
```

So passing any `framerate` to `GodotEnv` currently stops the game from launching.

The fix splits it into two tokens. I also pulled the argv construction into `GodotEnv._build_launch_cmd` so it can be unit tested without a game binary, and added tests for the flag forms. Everything else keeps the `--key=value` shape the plugin parses.