### PR TITLE
Implement step_async and step_wait

### DIFF
--- a/godot_rl/wrappers/stable_baselines_wrapper.py
+++ b/godot_rl/wrappers/stable_baselines_wrapper.py
@@ -43,9 +43,6 @@ class StableBaselinesGodotEnv(VecEnv):
         # Check the action space for validity
         self._check_valid_action_space()
 
-        # Initialize the results holder
-        self.results = None
-
     def _check_valid_action_space(self) -> None:
         # Check if the action space is a tuple space with multiple spaces
         action_space = self.envs[0].action_space
@@ -55,39 +52,8 @@ class StableBaselinesGodotEnv(VecEnv):
             ), f"sb3 supports a single action space, this env contains multiple spaces {action_space}"
 
     def step(self, action: np.ndarray) -> Tuple[Dict[str, np.ndarray], np.ndarray, np.ndarray, List[Dict[str, Any]]]:
-        # Initialize lists for collecting results
-        all_obs = []
-        all_rewards = []
-        all_term = []
-        all_trunc = []
-        all_info = []
-
-        # Get the number of environments
-        num_envs = self.envs[0].num_envs
-
-        # Send actions to each environment
-        for i in range(self.n_parallel):
-            self.envs[i].step_send(action[i * num_envs : (i + 1) * num_envs])
-
-        # Receive results from each environment
-        for i in range(self.n_parallel):
-            obs, reward, term, trunc, info = self.envs[i].step_recv()
-            all_obs.extend(obs)
-            all_rewards.extend(reward)
-            all_term.extend(term)
-            all_trunc.extend(trunc)
-            all_info.extend(info)
-
-        # Convert list of dictionaries to dictionary of lists
-        obs = lod_to_dol(all_obs)
-
-        # Return results
-        return (
-            {k: np.array(v) for k, v in obs.items()},
-            np.array(all_rewards, dtype=np.float32),
-            np.array(all_term),
-            all_info,
-        )
+        self.step_async(action)
+        return self.step_wait()
 
     def reset(self) -> Dict[str, np.ndarray]:
         # Initialize lists for collecting results
@@ -142,14 +108,40 @@ class StableBaselinesGodotEnv(VecEnv):
         raise NotImplementedError()
 
     def step_async(self, actions: np.ndarray) -> None:
-        # Execute the step function asynchronously, not actually implemented in this setting
-        self.results = self.step(actions)
+        # Send the actions to every environment, then return without waiting for the results
+        num_envs = self.envs[0].num_envs
+
+        for i in range(self.n_parallel):
+            self.envs[i].step_send(actions[i * num_envs : (i + 1) * num_envs])
 
     def step_wait(
         self,
     ) -> Tuple[Dict[str, np.ndarray], np.ndarray, np.ndarray, List[Dict[str, Any]]]:
-        # Wait for the results from the asynchronous step
-        return self.results
+        # Collect the results of the actions sent by step_async
+        all_obs = []
+        all_rewards = []
+        all_term = []
+        all_trunc = []
+        all_info = []
+
+        for i in range(self.n_parallel):
+            obs, reward, term, trunc, info = self.envs[i].step_recv()
+            all_obs.extend(obs)
+            all_rewards.extend(reward)
+            all_term.extend(term)
+            all_trunc.extend(trunc)
+            all_info.extend(info)
+
+        # Convert list of dictionaries to dictionary of lists
+        obs = lod_to_dol(all_obs)
+
+        # Return results
+        return (
+            {k: np.array(v) for k, v in obs.items()},
+            np.array(all_rewards, dtype=np.float32),
+            np.array(all_term),
+            all_info,
+        )
 
 
 def stable_baselines_training(args, extras, n_steps: int = 200000, **kwargs) -> None:

--- a/tests/test_sb3_step_async.py
+++ b/tests/test_sb3_step_async.py
@@ -1,0 +1,85 @@
+import numpy as np
+
+from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
+
+
+class FakeGodotEnv:
+    """Stand in for GodotEnv that records the order of the send and receive calls."""
+
+    def __init__(self, index, num_envs, calls):
+        self.index = index
+        self.num_envs = num_envs
+        self.calls = calls
+        self.sent_actions = None
+
+    def step_send(self, action):
+        self.calls.append(("send", self.index))
+        self.sent_actions = action
+
+    def step_recv(self):
+        self.calls.append(("recv", self.index))
+        obs = [{"obs": np.full(2, float(self.index))} for _ in range(self.num_envs)]
+        reward = [float(self.index)] * self.num_envs
+        term = [False] * self.num_envs
+        trunc = [False] * self.num_envs
+        info = [{}] * self.num_envs
+        return obs, reward, term, trunc, info
+
+
+def make_env(n_parallel=3, num_envs=2):
+    # Bypass __init__ so no Godot game is launched
+    env = object.__new__(StableBaselinesGodotEnv)
+    calls = []
+    env.envs = [FakeGodotEnv(i, num_envs, calls) for i in range(n_parallel)]
+    env.n_parallel = n_parallel
+    return env, calls
+
+
+def test_step_async_only_sends():
+    env, calls = make_env()
+    env.step_async(np.zeros((6, 1)))
+    assert calls == [("send", 0), ("send", 1), ("send", 2)]
+
+
+def test_step_wait_collects_after_step_async():
+    env, calls = make_env()
+    env.step_async(np.zeros((6, 1)))
+    env.step_wait()
+    assert [kind for kind, _ in calls] == ["send"] * 3 + ["recv"] * 3
+
+
+def test_step_still_sends_everything_before_the_first_receive():
+    env, calls = make_env()
+    env.step(np.zeros((6, 1)))
+    assert [kind for kind, _ in calls] == ["send"] * 3 + ["recv"] * 3
+
+
+def test_actions_are_split_across_environments():
+    env, _ = make_env(n_parallel=3, num_envs=2)
+    env.step_async(np.arange(6).reshape(6, 1))
+    assert env.envs[0].sent_actions.tolist() == [[0], [1]]
+    assert env.envs[1].sent_actions.tolist() == [[2], [3]]
+    assert env.envs[2].sent_actions.tolist() == [[4], [5]]
+
+
+def test_results_keep_the_environment_order():
+    env, _ = make_env(n_parallel=3, num_envs=2)
+    obs, rewards, dones, infos = env.step(np.zeros((6, 1)))
+    assert rewards.tolist() == [0.0, 0.0, 1.0, 1.0, 2.0, 2.0]
+    assert obs["obs"].shape == (6, 2)
+    assert dones.tolist() == [False] * 6
+    assert len(infos) == 6
+
+
+def test_step_and_the_async_pair_agree():
+    env_a, _ = make_env()
+    env_b, _ = make_env()
+    actions = np.arange(6).reshape(6, 1)
+
+    obs_a, rewards_a, dones_a, _ = env_a.step(actions)
+    env_b.step_async(actions)
+    obs_b, rewards_b, dones_b, _ = env_b.step_wait()
+
+    assert np.array_equal(obs_a["obs"], obs_b["obs"])
+    assert np.array_equal(rewards_a, rewards_b)
+    assert np.array_equal(dones_a, dones_b)


### PR DESCRIPTION
`step_async` currently runs the whole step and caches the result:

```python
def step_async(self, actions):
    # Execute the step function asynchronously, not actually implemented in this setting
    self.results = self.step(actions)

def step_wait(self):
    return self.results
```

So the split the `VecEnv` API is built around is not there. A caller that does `step_async`, gets on with something else, then calls `step_wait` still pays the whole receive cost inside `step_async`.

This moves the send loop into `step_async`, the receive loop into `step_wait`, and leaves `step` as the two called in order. `GodotEnv` already exposes `step_send` and `step_recv`, so nothing changes on the protocol or plugin side.

Results are identical and actions still reach every game before the first receive, so the existing overlap between parallel instances is preserved. The tests pin the call order and check that `step` matches `step_async` followed by `step_wait`.