### PR TITLE
Forward the reset seed and implement VecEnv.seed

### DIFF
--- a/godot_rl/core/godot_env.py
+++ b/godot_rl/core/godot_env.py
@@ -244,12 +244,18 @@ class GodotEnv:
         """
         Reset the Godot environment.
 
+        Args:
+            seed (int): optional seed sent to the game along with the reset request.
+
         Returns:
             dict: The initial observation data.
         """
         message = {
             "type": "reset",
         }
+        if seed is not None:
+            # int() as numpy integers are not json serializable
+            message["seed"] = int(seed)
         self._send_as_json(message)
         response = self._get_json_dict()
         response["obs"] = self._process_obs(response["obs"])

--- a/godot_rl/wrappers/stable_baselines_wrapper.py
+++ b/godot_rl/wrappers/stable_baselines_wrapper.py
@@ -46,6 +46,9 @@ class StableBaselinesGodotEnv(VecEnv):
         # Initialize the results holder
         self.results = None
 
+        # Seeds latched by seed(), applied on the next reset
+        self._seeds: List[Optional[int]] = [None] * n_parallel
+
     def _check_valid_action_space(self) -> None:
         # Check if the action space is a tuple space with multiple spaces
         action_space = self.envs[0].action_space
@@ -94,11 +97,14 @@ class StableBaselinesGodotEnv(VecEnv):
         all_obs = []
         all_info = []
 
-        # Reset each environment
+        # Reset each environment, applying any seed latched by seed()
         for i in range(self.n_parallel):
-            obs, info = self.envs[i].reset()
+            obs, info = self.envs[i].reset(seed=self._seeds[i])
             all_obs.extend(obs)
             all_info.extend(info)
+
+        # A latched seed applies to one reset only, as in sb3's own vec envs
+        self._seeds = [None] * self.n_parallel
 
         # Convert list of dictionaries to dictionary of lists
         obs = lod_to_dol(all_obs)
@@ -135,8 +141,14 @@ class StableBaselinesGodotEnv(VecEnv):
             return [None for _ in range(self.num_envs)]
         raise AttributeError("get attr not fully implemented in godot-rl StableBaselinesWrapper")
 
-    def seed(self, seed=None):
-        raise NotImplementedError()
+    def seed(self, seed: Optional[int] = None) -> List[Optional[int]]:
+        # Each parallel game gets seed + p, matching the offsets used when they were launched.
+        # The seeds are latched here and sent with the next reset.
+        if seed is None:
+            self._seeds = [None] * self.n_parallel
+        else:
+            self._seeds = [seed + p for p in range(self.n_parallel)]
+        return list(self._seeds)
 
     def set_attr(self):
         raise NotImplementedError()

--- a/tests/test_seeding.py
+++ b/tests/test_seeding.py
@@ -1,0 +1,87 @@
+import numpy as np
+
+from godot_rl.core.godot_env import GodotEnv
+from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
+
+
+def make_godot_env():
+    # Bypass __init__ so no game is launched, and record what would go on the socket
+    env = object.__new__(GodotEnv)
+    env.num_envs = 1
+    env.sent = []
+    env._send_as_json = env.sent.append
+    env._get_json_dict = lambda: {"type": "reset", "obs": [{"obs": [0.0]}]}
+    env._process_obs = lambda obs: obs
+    return env
+
+
+def test_reset_without_a_seed_is_unchanged():
+    env = make_godot_env()
+    env.reset()
+    assert env.sent == [{"type": "reset"}]
+
+
+def test_reset_forwards_the_seed():
+    env = make_godot_env()
+    env.reset(seed=42)
+    assert env.sent == [{"type": "reset", "seed": 42}]
+
+
+def test_numpy_seeds_are_converted_to_int():
+    # json.dumps cannot serialize numpy integers
+    env = make_godot_env()
+    env.reset(seed=np.int64(7))
+    assert type(env.sent[0]["seed"]) is int
+    assert env.sent[0]["seed"] == 7
+
+
+class FakeGodotEnv:
+    def __init__(self, num_envs):
+        self.num_envs = num_envs
+        self.reset_seed = "not reset yet"
+
+    def reset(self, seed=None):
+        self.reset_seed = seed
+        return [{"obs": np.zeros(2)} for _ in range(self.num_envs)], [{}] * self.num_envs
+
+
+def make_vec_env(n_parallel=3, num_envs=1):
+    env = object.__new__(StableBaselinesGodotEnv)
+    env.envs = [FakeGodotEnv(num_envs) for _ in range(n_parallel)]
+    env.n_parallel = n_parallel
+    env._seeds = [None] * n_parallel
+    return env
+
+
+def test_seed_returns_one_seed_per_parallel_game():
+    env = make_vec_env(3)
+    assert env.seed(10) == [10, 11, 12]
+
+
+def test_latched_seeds_reach_the_games_on_the_next_reset():
+    env = make_vec_env(3)
+    env.seed(10)
+    env.reset()
+    assert [e.reset_seed for e in env.envs] == [10, 11, 12]
+
+
+def test_a_seed_applies_to_a_single_reset():
+    env = make_vec_env(2)
+    env.seed(5)
+    env.reset()
+    env.reset()
+    assert [e.reset_seed for e in env.envs] == [None, None]
+
+
+def test_reset_without_seeding_sends_no_seed():
+    env = make_vec_env(2)
+    env.reset()
+    assert [e.reset_seed for e in env.envs] == [None, None]
+
+
+def test_seed_none_clears_the_latch():
+    env = make_vec_env(2)
+    env.seed(5)
+    assert env.seed(None) == [None, None]
+    env.reset()
+    assert [e.reset_seed for e in env.envs] == [None, None]


### PR DESCRIPTION
Two related gaps in seeding.

`GodotEnv.reset` accepts a seed and drops it. The reset message is built without it, so gymnasium style reseeding on reset is silently a no op:

```python
def reset(self, seed=None):
    message = {
        "type": "reset",
    }
```

`StableBaselinesGodotEnv.seed` raises `NotImplementedError`. sb3 calls `env.seed()` when an algorithm is built with a seed, so `PPO(..., seed=0)` on a godot env crashes rather than training.

`reset` now sends the seed with the reset message, and the wrapper latches one seed per parallel game using the same `seed + p` offsets the constructor already uses, applied on the next reset and cleared afterwards, which is how sb3's own vec envs behave.

The wire change is additive. The current plugin reads only `message["type"]` in its reset handler and ignores extra keys, so this is safe against existing games. For the seed to actually take effect in game, that handler in `sync.gd` needs to read it, which is a three line change in godot_rl_agents_plugin. I am happy to open that PR as well if you want to take this.

Related to #124, which covered the same area on the Godot side.