### PR TITLE
Add an option to cap the torch thread count

### DIFF
--- a/examples/stable_baselines3_example.py
+++ b/examples/stable_baselines3_example.py
@@ -7,7 +7,7 @@ from stable_baselines3 import PPO
 from stable_baselines3.common.callbacks import CheckpointCallback
 from stable_baselines3.common.vec_env.vec_monitor import VecMonitor
 
-from godot_rl.core.utils import can_import
+from godot_rl.core.utils import can_import, set_torch_threads
 from godot_rl.wrappers.onnx.stable_baselines_export import export_model_as_onnx
 from godot_rl.wrappers.stable_baselines_wrapper import StableBaselinesGodotEnv
 
@@ -134,8 +134,18 @@ parser.add_argument(
     type=float,
     help="The clipping range (default 0.2). This limits the policy changes per update",
 )
+parser.add_argument(
+    "--torch_num_threads",
+    default=None,
+    type=int,
+    help="Threads torch may use for intra op parallelism. Torch takes one per core by default, "
+    "which oversubscribes the machine once several game instances run next to the learner. "
+    "Try 1 when raising --n_parallel on a many core machine.",
+)
 
 args, extras = parser.parse_known_args()
+
+set_torch_threads(args.torch_num_threads)
 
 
 def handle_onnx_export():

--- a/godot_rl/core/utils.py
+++ b/godot_rl/core/utils.py
@@ -1,5 +1,6 @@
 import importlib
 import re
+from typing import Optional
 
 import gymnasium as gym
 import numpy as np
@@ -131,6 +132,30 @@ class ActionSpaceProcessor:
                 raise NotImplementedError
 
         return original_action
+
+
+def set_torch_threads(num_threads: Optional[int]) -> Optional[int]:
+    """Limit the threads torch uses for intra op parallelism.
+
+    Torch allocates one thread per core by default. With several game instances running
+    next to the learner this oversubscribes the machine and the learner update slows down
+    a lot, which is most visible on many core machines with a high --n_parallel.
+
+    Args:
+        num_threads (int): thread count to apply, or None to leave torch alone.
+
+    Returns:
+        int: the applied thread count, or None if nothing was changed.
+    """
+    if num_threads is None:
+        return None
+    if num_threads < 1:
+        raise ValueError(f"num_threads must be 1 or more, got {num_threads}")
+
+    import torch
+
+    torch.set_num_threads(num_threads)
+    return num_threads
 
 
 def can_import(module_name):

--- a/tests/test_torch_threads.py
+++ b/tests/test_torch_threads.py
@@ -1,0 +1,25 @@
+import pytest
+import torch
+
+from godot_rl.core.utils import set_torch_threads
+
+
+def test_none_leaves_torch_untouched():
+    before = torch.get_num_threads()
+    assert set_torch_threads(None) is None
+    assert torch.get_num_threads() == before
+
+
+def test_applies_the_requested_count():
+    before = torch.get_num_threads()
+    try:
+        assert set_torch_threads(1) == 1
+        assert torch.get_num_threads() == 1
+    finally:
+        torch.set_num_threads(before)
+
+
+@pytest.mark.parametrize("num_threads", [0, -1])
+def test_rejects_counts_below_one(num_threads):
+    with pytest.raises(ValueError):
+        set_torch_threads(num_threads)


### PR DESCRIPTION
Torch takes one intra op thread per core by default. As soon as several game instances run next to the learner, which is the point of `--n_parallel`, the machine is oversubscribed and the update step slows right down. It is easy to miss because nothing fails, the run is just slow, and it gets worse the more cores the machine has. I hit this on a 32 core node where raising `n_parallel` stopped buying any throughput at all.

`examples/stable_baselines3_hp_tuning.py:169` already calls `torch.set_num_threads(1)` for the same reason, so this just makes the knob reachable from the normal training path.

Adds `set_torch_threads` in `core.utils` and a `--torch_num_threads` flag to the sb3 example. The default is `None`, so nothing changes unless the flag is passed. The torch import sits inside the helper so `core.utils` does not pull torch in at import time.